### PR TITLE
feat: add postgres support for event handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,93 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "asn1_der"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
-
-[[package]]
-name = "async-io"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,16 +160,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
+name = "async_fn_traits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+checksum = "bc58d489c5f2d2c5be31b9004cec7af25a70d23df4d8111715eee736234cf217"
 dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
+ "paste",
 ]
 
 [[package]]
@@ -282,17 +191,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "attohttpc"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
-dependencies = [
- "http 0.2.12",
- "log",
- "url",
-]
 
 [[package]]
 name = "autocfg"
@@ -408,12 +306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,7 +344,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.79",
 ]
@@ -470,6 +362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -491,15 +392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
 ]
 
 [[package]]
@@ -547,9 +439,6 @@ name = "bytes"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2-sys"
@@ -560,15 +449,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "cbor4ii"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472931dd4dfcc785075b09be910147f9c6258883fc4591d0dac6116392b2daa6"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -756,29 +636,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -863,33 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,26 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
-name = "data-encoding-macro"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
-dependencies = [
- "data-encoding",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,20 +773,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -1022,27 +822,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "duration-human"
@@ -1062,31 +845,6 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "either"
@@ -1148,16 +906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eventus"
 version = "0.2.0"
 source = "git+https://github.com/tqwewe/eventus?branch=feat/transactions#8f289a9e1c505ab87669955d9f589c3d5518248d"
@@ -1209,12 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,7 +980,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -1246,12 +988,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1294,16 +1030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-bounded"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
-dependencies = [
- "futures-timer",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,7 +1054,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1349,16 +1074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,17 +1082,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
-dependencies = [
- "futures-io",
- "rustls 0.23.15",
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -1391,23 +1095,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1529,11 +1216,6 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
@@ -1570,22 +1252,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex_fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -1604,7 +1274,6 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -1845,7 +1514,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -1884,51 +1553,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-addrs"
-version = "0.10.2"
+name = "im"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "if-watch"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
-dependencies = [
- "async-io",
- "core-foundation",
- "fnv",
- "futures",
- "if-addrs",
- "ipnet",
- "log",
- "rtnetlink",
- "system-configuration",
- "tokio",
- "windows",
-]
-
-[[package]]
-name = "igd-next"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
-dependencies = [
- "async-trait",
- "attohttpc",
- "bytes",
- "futures",
- "http 0.2.12",
- "hyper 0.14.30",
- "log",
- "rand",
- "tokio",
- "url",
- "xmltree",
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1949,25 +1584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
- "serde",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "internment"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
-dependencies = [
  "hashbrown 0.15.0",
  "serde",
 ]
@@ -2061,14 +1677,9 @@ version = "0.12.2"
 dependencies = [
  "dyn-clone",
  "futures",
- "internment",
  "itertools 0.13.0",
  "kameo_macros 0.12.2",
- "libp2p",
- "libp2p-identity",
- "linkme",
  "once_cell",
- "rmp-serde",
  "serde",
  "tokio",
  "tokio-stream",
@@ -2081,11 +1692,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "async_fn_traits",
  "bson",
  "chrono",
  "ciborium",
  "eventus",
  "futures",
+ "im",
  "kameo 0.12.2",
  "mongodb",
  "polodb_core",
@@ -2098,6 +1711,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.12.3",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2154,7 +1768,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2186,360 +1800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "libp2p"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-dns",
- "libp2p-gossipsub",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-metrics",
- "libp2p-quic",
- "libp2p-request-response",
- "libp2p-swarm",
- "libp2p-tcp",
- "libp2p-upnp",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand",
- "rw-stream-sink",
- "serde",
- "smallvec",
- "thiserror",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
-dependencies = [
- "async-trait",
- "futures",
- "hickory-resolver",
- "libp2p-core",
- "libp2p-identity",
- "parking_lot",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
-dependencies = [
- "asynchronous-codec",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-ticker",
- "getrandom",
- "hex_fmt",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "prometheus-client",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand",
- "regex",
- "serde",
- "sha2",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-identity"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "hkdf",
- "multihash",
- "quick-protobuf",
- "rand",
- "ring 0.17.8",
- "serde",
- "sha2",
- "thiserror",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
-dependencies = [
- "arrayvec",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand",
- "serde",
- "sha2",
- "smallvec",
- "thiserror",
- "tracing",
- "uint",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
-dependencies = [
- "data-encoding",
- "futures",
- "hickory-proto",
- "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "rand",
- "smallvec",
- "socket2",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
-dependencies = [
- "futures",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-swarm",
- "pin-project",
- "prometheus-client",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-tls",
- "parking_lot",
- "quinn",
- "rand",
- "ring 0.17.8",
- "rustls 0.23.15",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
-dependencies = [
- "async-trait",
- "cbor4ii",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "rand",
- "serde",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm-derive",
- "lru",
- "multistream-select",
- "once_cell",
- "rand",
- "smallvec",
- "tokio",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core",
- "libp2p-identity",
- "socket2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core",
- "libp2p-identity",
- "rcgen",
- "ring 0.17.8",
- "rustls 0.23.15",
- "rustls-webpki 0.101.7",
- "thiserror",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-upnp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next",
- "libp2p-core",
- "libp2p-swarm",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,26 +1828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "linkme"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c943daedff228392b791b33bba32e75737756e80a613e32e246c6ce9cbab20a"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,15 +1848,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.0",
-]
 
 [[package]]
 name = "lru-cache"
@@ -2700,7 +1931,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2734,7 +1965,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "rustc_version_runtime",
- "rustls 0.21.12",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_bytes",
@@ -2766,142 +1997,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "libp2p-identity",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.8.0",
- "url",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
-dependencies = [
- "core2",
- "serde",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "netlink-packet-core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
-dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror",
-]
-
-[[package]]
-name = "netlink-proto"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-sys",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
-dependencies = [
- "bytes",
- "futures",
- "libc",
- "log",
- "tokio",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "nom"
@@ -2921,16 +2020,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2987,31 +2076,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
 ]
 
 [[package]]
@@ -3078,16 +2148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
 ]
 
 [[package]]
@@ -3175,21 +2235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "polling"
-version = "3.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "polodb-librocksdb-sys"
 version = "9.0.0-alpha.1"
 dependencies = [
@@ -3250,29 +2295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -3367,77 +2389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
-dependencies = [
- "bytes",
- "futures-io",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls 0.23.15",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
-dependencies = [
- "bytes",
- "rand",
- "ring 0.17.8",
- "rustc-hash 2.0.0",
- "rustls 0.23.15",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
-dependencies = [
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,15 +2434,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.11.3"
+name = "rand_xoshiro"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "pem",
- "ring 0.16.20",
- "time",
- "yasna",
+ "rand_core",
 ]
 
 [[package]]
@@ -3559,21 +2507,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -3582,8 +2515,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3630,21 +2563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtnetlink"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-route",
- "netlink-proto",
- "nix",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,12 +2589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,15 +2605,6 @@ checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
  "rustc_version",
  "semver",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -3724,23 +2627,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
+ "ring",
+ "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
-dependencies = [
- "once_cell",
- "ring 0.17.8",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3753,30 +2642,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring 0.17.8",
- "rustls-pki-types",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3784,17 +2656,6 @@ name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
 
 [[package]]
 name = "ryu"
@@ -3814,8 +2675,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3976,6 +2837,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,12 +2873,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4300,38 +3165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,7 +3311,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.12",
+ "rustls",
  "tokio",
 ]
 
@@ -4722,18 +3555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,24 +3586,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4835,12 +3638,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"
@@ -4919,26 +3716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
-name = "web-sys"
-version = "0.3.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,25 +3758,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
-dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-core"
@@ -5175,47 +3933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
-
-[[package]]
-name = "xmltree"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
-dependencies = [
- "xml-rs",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
+name = "async-io"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +247,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +282,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+dependencies = [
+ "http 0.2.12",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -282,6 +408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,7 +452,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.79",
 ]
@@ -330,6 +468,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -353,6 +494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bson"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +511,7 @@ dependencies = [
  "ahash",
  "base64 0.13.1",
  "bitvec",
+ "chrono",
  "hex",
  "indexmap 2.6.0",
  "js-sys",
@@ -396,6 +547,9 @@ name = "bytes"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -406,6 +560,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "cbor4ii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472931dd4dfcc785075b09be910147f9c6258883fc4591d0dac6116392b2daa6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -534,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console-api"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,16 +744,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -591,6 +788,21 @@ checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -620,6 +832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +860,33 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -683,6 +931,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+dependencies = [
+ "data-encoding",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,9 +1016,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "duration-human"
@@ -747,10 +1064,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -781,6 +1126,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventus"
 version = "0.2.0"
 source = "git+https://github.com/tqwewe/eventus?branch=feat/transactions#8f289a9e1c505ab87669955d9f589c3d5518248d"
@@ -795,7 +1172,7 @@ dependencies = [
  "fslock",
  "futures",
  "itertools 0.13.0",
- "kameo",
+ "kameo 0.12.0",
  "memmap2",
  "page_size",
  "prost 0.13.3",
@@ -832,6 +1209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,10 +1231,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "form_urlencoded"
@@ -894,6 +1294,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1328,18 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -925,6 +1347,16 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -938,6 +1370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls 0.23.15",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1391,23 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1061,6 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1068,6 +1529,11 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1104,10 +1570,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -1126,6 +1604,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
+ "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -1155,12 +1634,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1348,7 +1845,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1387,6 +1884,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
+dependencies = [
+ "async-io",
+ "core-foundation",
+ "fnv",
+ "futures",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
+ "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rand",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1949,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
+ "hashbrown 0.15.0",
+ "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "internment"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
  "hashbrown 0.15.0",
  "serde",
 ]
@@ -1483,8 +2047,28 @@ dependencies = [
  "dyn-clone",
  "futures",
  "itertools 0.13.0",
- "kameo_macros",
+ "kameo_macros 0.12.0",
  "once_cell",
+ "serde",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "kameo"
+version = "0.12.2"
+dependencies = [
+ "dyn-clone",
+ "futures",
+ "internment",
+ "itertools 0.13.0",
+ "kameo_macros 0.12.2",
+ "libp2p",
+ "libp2p-identity",
+ "linkme",
+ "once_cell",
+ "rmp-serde",
  "serde",
  "tokio",
  "tokio-stream",
@@ -1497,16 +2081,18 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "bson",
  "chrono",
  "ciborium",
  "eventus",
  "futures",
- "kameo",
+ "kameo 0.12.2",
  "mongodb",
  "polodb_core",
  "prost-types 0.13.3",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1520,6 +2106,17 @@ name = "kameo_macros"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3607663e195d5d0a09f87a1d911e52a4c5b44cb8d8c104b39008f7721fe78be7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "uuid",
+]
+
+[[package]]
+name = "kameo_macros"
+version = "0.12.2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1556,6 +2153,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "lazycell"
@@ -1577,6 +2177,366 @@ checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libp2p"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-gossipsub",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand",
+ "rw-stream-sink",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-ticker",
+ "getrandom",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand",
+ "regex",
+ "serde",
+ "sha2",
+ "smallvec",
+ "tracing",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "hkdf",
+ "multihash",
+ "quick-protobuf",
+ "rand",
+ "ring 0.17.8",
+ "serde",
+ "sha2",
+ "thiserror",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+dependencies = [
+ "arrayvec",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand",
+ "serde",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "uint",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+dependencies = [
+ "data-encoding",
+ "futures",
+ "hickory-proto",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand",
+ "smallvec",
+ "socket2",
+ "tokio",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-swarm",
+ "pin-project",
+ "prometheus-client",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "parking_lot",
+ "quinn",
+ "rand",
+ "ring 0.17.8",
+ "rustls 0.23.15",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+dependencies = [
+ "async-trait",
+ "cbor4ii",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand",
+ "serde",
+ "smallvec",
+ "tracing",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
+ "lru",
+ "multistream-select",
+ "once_cell",
+ "rand",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "libp2p-identity",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring 0.17.8",
+ "rustls 0.23.15",
+ "rustls-webpki 0.101.7",
+ "thiserror",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+ "void",
 ]
 
 [[package]]
@@ -1608,6 +2568,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c943daedff228392b791b33bba32e75737756e80a613e32e246c6ce9cbab20a"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +2608,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
+]
 
 [[package]]
 name = "lru-cache"
@@ -1711,7 +2700,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1745,7 +2734,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "rustc_version_runtime",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_bytes",
@@ -1777,10 +2766,142 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.8.0",
+ "url",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+dependencies = [
+ "core2",
+ "serde",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -1803,10 +2924,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1815,6 +2983,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -1824,6 +3003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1847,6 +3035,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1884,6 +3078,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1935,10 +3148,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "polling"
+version = "3.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "polodb-librocksdb-sys"
@@ -2001,6 +3250,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2095,6 +3367,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.15",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.15",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +3480,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+dependencies = [
+ "pem",
+ "ring 0.16.20",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2204,6 +3559,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -2212,8 +3582,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2237,6 +3607,41 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-route",
+ "netlink-proto",
+ "nix",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2266,6 +3671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +3693,15 @@ checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
  "rustc_version",
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2304,9 +3724,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+dependencies = [
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2319,13 +3753,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2333,6 +3784,17 @@ name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
+]
 
 [[package]]
 name = "ryu"
@@ -2352,8 +3814,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2405,6 +3867,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +3913,17 @@ name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2481,6 +3966,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +3989,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2507,9 +4005,236 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+dependencies = [
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "hashlink",
+ "hex",
+ "indexmap 2.6.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.79",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2573,6 +4298,38 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "take_mut"
@@ -2721,7 +4478,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -2874,6 +4631,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2964,6 +4722,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +4759,30 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3043,6 +4837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +4856,12 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3113,10 +4919,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
+name = "web-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
 
 [[package]]
 name = "widestring"
@@ -3145,6 +4981,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core 0.51.1",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-core"
@@ -3323,6 +5178,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,3 +5238,9 @@ dependencies = [
  "quote",
  "syn 2.0.79",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.82"
+async_fn_traits = "0.1.1"
 async-recursion = "1.1.1"
 bson = { version = "2.13.0", features = ["chrono-0_4", "uuid-1"], optional = true }
 # cbor4ii = { version = "0.3.3", features = ["serde1"] }
@@ -12,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ciborium = "0.2.2"
 eventus = { git = "https://github.com/tqwewe/eventus", branch = "feat/transactions" }
 futures = "0.3.30"
+im = "15.1.0"
 kameo = { path = "../kameo" } # "0.12.0"
 mongodb = { version = "3.1.0", optional = true }
 polodb_core = { path = "../../PoloDB/PoloDB/src/polodb_core", optional = true } # "5.1.2"
@@ -24,6 +26,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7.11"
 tonic = "0.12"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 uuid = { version = "1.10", features = ["serde", "v4"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,19 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.82"
 async-recursion = "1.1.1"
+bson = { version = "2.13.0", features = ["chrono-0_4", "uuid-1"], optional = true }
 # cbor4ii = { version = "0.3.3", features = ["serde1"] }
 chrono = { version = "0.4", features = ["serde"] }
 ciborium = "0.2.2"
 eventus = { git = "https://github.com/tqwewe/eventus", branch = "feat/transactions" }
 futures = "0.3.30"
-kameo = "0.12.0"
+kameo = { path = "../kameo" } # "0.12.0"
 mongodb = { version = "3.1.0", optional = true }
 polodb_core = { path = "../../PoloDB/PoloDB/src/polodb_core", optional = true } # "5.1.2"
 prost-types = "0.13.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "*"
+sqlx = { version = "0.8", features = [ "runtime-tokio" ], optional = true }
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7.11"
@@ -25,10 +27,16 @@ tracing = "0.1"
 uuid = { version = "1.10", features = ["serde", "v4"] }
 
 [features]
-default = ["mongodb"]
+default = []
 mongodb = [
+  "dep:bson",
   "dep:mongodb"
 ]
 polodb = [
   "dep:polodb_core"
+]
+postgres = [
+  "dep:sqlx",
+  "sqlx/postgres",
+  "sqlx/uuid"
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1729256560,
+        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1725157860,
-        "narHash": "sha256-DhqyM7XJYKj+WAEaYwMtXaYX66tA+lOd31sd5QkxLDM=",
+        "lastModified": 1729564184,
+        "narHash": "sha256-dP764PQ6YhjY7C84Txnrb2vf0H2YdQlp5c6a7G18fgw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1fd72e343c6890f695243a37b367a1e3b90a49ee",
+        "rev": "d687672b4541496408068bc273d94c643005d4c9",
         "type": "github"
       },
       "original": {

--- a/src/command_service.rs
+++ b/src/command_service.rs
@@ -156,6 +156,22 @@ pub enum ExecuteResult<E> {
     Idempotent,
 }
 
+impl<E> ExecuteResult<E> {
+    pub fn len(&self) -> usize {
+        match self {
+            ExecuteResult::Executed(events) => events.len(),
+            ExecuteResult::Idempotent => 0,
+        }
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = AppendedEvent<E>> {
+        match self {
+            ExecuteResult::Executed(events) => events.into_iter(),
+            ExecuteResult::Idempotent => vec![].into_iter(),
+        }
+    }
+}
+
 impl<'a, E, C> Execute<'a, E, C>
 where
     E: Entity,

--- a/src/command_service.rs
+++ b/src/command_service.rs
@@ -1,9 +1,11 @@
 use std::{
-    any, collections::HashMap, fmt, future::IntoFuture, marker::PhantomData, sync::Arc,
-    time::Instant,
+    any, collections::HashMap, fmt, future::IntoFuture, marker::PhantomData, time::Instant,
+    vec::IntoIter,
 };
 
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
+use ciborium::Value;
 use eventus::{
     server::{eventstore::event_store_client::EventStoreClient, ClientAuthInterceptor},
     ExpectedVersion,
@@ -19,15 +21,16 @@ use kameo::{
     Actor,
 };
 use tonic::{service::interceptor::InterceptedService, transport::Channel};
-use tracing::error;
+use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::{
     entity_actor::{self, EntityActor},
     error::ExecuteError,
-    event_store::{new_event_store, EventStore},
+    event_store::{AppendEvents, AppendEventsError, EventStore},
     stream_id::StreamID,
-    Apply, CausationMetadata, Command, Entity, Event, Metadata, Transaction, TransactionSender,
+    transaction::Transaction,
+    Apply, CausationMetadata, Command, Entity, Event, EventType, GenericValue, Metadata,
 };
 
 #[derive(Clone, Debug)]
@@ -42,16 +45,7 @@ impl CommandService {
     pub fn new(
         client: EventStoreClient<InterceptedService<Channel, ClientAuthInterceptor>>,
     ) -> Self {
-        Self::new_with_workers(client, 16)
-    }
-
-    /// Creates a new command service using an event store client connection and worker count.
-    #[inline]
-    pub fn new_with_workers(
-        client: EventStoreClient<InterceptedService<Channel, ClientAuthInterceptor>>,
-        workers: usize,
-    ) -> Self {
-        let event_store = new_event_store(client, workers);
+        let event_store = EventStore::new(client);
         let actor_ref = kameo::spawn(CommandServiceActor {
             event_store: event_store.clone(),
             entities: HashMap::new(),
@@ -70,9 +64,62 @@ impl CommandService {
     }
 
     /// Starts a transaction.
-    #[inline]
-    pub fn transaction(&self) -> Transaction {
-        Transaction::new(self.event_store.clone())
+    pub async fn transaction<T, F>(&mut self, mut f: F) -> anyhow::Result<T>
+    where
+        F: FnMut(Transaction<'_>) -> BoxFuture<'_, anyhow::Result<T>>,
+    {
+        let id = Transaction::get_id();
+        let mut entities = HashMap::new();
+        let mut appends = Vec::new();
+        let mut attempt = 0;
+        loop {
+            let tx = Transaction::new(id, self, &mut entities, &mut appends);
+            let res = f(tx).await;
+            match res {
+                Ok(val) => {
+                    let current_appends: Vec<_> = appends
+                        .drain(..)
+                        .filter(|append| !append.events.is_empty())
+                        .collect();
+                    if current_appends.is_empty() {
+                        Transaction::new(id, self, &mut entities, &mut appends).committed();
+                        return Ok(val);
+                    }
+
+                    // Attempt the transaction
+                    let res = self.event_store.append_to_streams(current_appends).await;
+                    match res {
+                        Ok(_) => {
+                            Transaction::new(id, self, &mut entities, &mut appends).committed();
+                            return Ok(val);
+                        }
+                        Err(AppendEventsError::IncorrectExpectedVersion {
+                            stream_id,
+                            current,
+                            expected,
+                            ..
+                        }) => {
+                            debug!(%stream_id, %current, %expected, "write conflict");
+                            if attempt >= 3 {
+                                Transaction::new(id, self, &mut entities, &mut appends).abort();
+                                return Err(anyhow!("too many conflict retries"));
+                            }
+
+                            attempt += 1;
+                            Transaction::new(id, self, &mut entities, &mut appends).reset();
+                        }
+                        Err(err) => {
+                            Transaction::new(id, self, &mut entities, &mut appends).abort();
+                            return Err(err.into());
+                        }
+                    }
+                }
+                Err(err) => {
+                    Transaction::new(id, self, &mut entities, &mut appends).abort();
+                    return Err(err.into());
+                }
+            }
+        }
     }
 }
 
@@ -85,8 +132,12 @@ struct CommandServiceActor {
 impl Actor for CommandServiceActor {
     type Mailbox = BoundedMailbox<Self>;
 
+    fn name() -> &'static str {
+        "CommandServiceActor"
+    }
+
     async fn on_stop(
-        self,
+        &mut self,
         _actor_ref: WeakActorRef<Self>,
         reason: ActorStopReason,
     ) -> Result<(), BoxError> {
@@ -115,27 +166,114 @@ impl Actor for CommandServiceActor {
     }
 }
 
-pub trait ExecuteExt<E, C>
+pub trait ExecuteExt<'a, E, C, T>
 where
     E: Entity + Command<C>,
 {
-    fn execute<'a>(cmd_service: &'a CommandService, id: E::ID, command: C) -> Execute<'a, E, C>;
+    type Transaction;
+
+    fn execute(cmd_service: T, id: E::ID, command: C) -> Execute<'a, E, C, Self::Transaction>;
 }
 
-impl<E, C> ExecuteExt<E, C> for E
+impl<'a, E, C> ExecuteExt<'a, E, C, &'a CommandService> for E
 where
     E: Entity + Command<C> + Apply + Default + Sync,
     E::Event: Clone,
     E::Error: fmt::Debug + Send + Sync,
     C: Clone + Send + 'static,
 {
-    fn execute<'a>(cmd_service: &'a CommandService, id: E::ID, command: C) -> Execute<'a, E, C> {
-        Execute::new(cmd_service, id, command)
+    type Transaction = ();
+
+    fn execute(cmd_service: &'a CommandService, id: E::ID, command: C) -> Execute<'a, E, C, ()> {
+        Execute::new(cmd_service, id, command, ())
+    }
+}
+
+impl<'a, 'b, E, C> ExecuteExt<'a, E, C, &'a mut Transaction<'b>> for E
+where
+    E: Entity + Command<C> + Apply + Default + Sync,
+    E::Event: Clone,
+    E::Error: fmt::Debug + Send + Sync,
+    C: Clone + Send + 'static,
+    'b: 'a,
+{
+    type Transaction = &'a mut Transaction<'b>;
+
+    fn execute(
+        tx: &'a mut Transaction<'b>,
+        id: E::ID,
+        command: C,
+    ) -> Execute<'a, E, C, &'a mut Transaction<'b>> {
+        Execute::new(&tx.cmd_service, id, command, tx)
     }
 }
 
 #[derive(Debug)]
-pub struct Execute<'a, E, C>
+pub enum ExecuteResult<E: Entity + Apply + Clone> {
+    /// The command was executed with the resulting events.
+    Executed(Vec<AppendedEvent<E::Event>>),
+    /// The command was executed and pending commit.
+    PendingTransaction {
+        entity_actor_ref: ActorRef<EntityActor<E>>,
+        events: Vec<E::Event>,
+        expected_version: ExpectedVersion,
+        correlation_id: Uuid,
+    },
+    /// The command was executed, but no new events due to idempotency
+    Idempotent,
+}
+
+pub enum ExecuteResultIter<E: Entity + Apply + Clone> {
+    Executed(IntoIter<AppendedEvent<E::Event>>),
+    PendingTransaction(IntoIter<E::Event>),
+    Idempotent,
+}
+
+impl<E: Entity + Apply + Clone> Iterator for ExecuteResultIter<E> {
+    type Item = E::Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ExecuteResultIter::Executed(events) => events.next().map(|append| append.event),
+            ExecuteResultIter::PendingTransaction(events) => events.next(),
+            ExecuteResultIter::Idempotent => None,
+        }
+    }
+}
+
+impl<E> ExecuteResult<E>
+where
+    E: Entity + Apply + Clone,
+{
+    pub fn len(&self) -> usize {
+        match self {
+            ExecuteResult::Executed(events) => events.len(),
+            ExecuteResult::PendingTransaction { events, .. } => events.len(),
+            ExecuteResult::Idempotent => 0,
+        }
+    }
+
+    pub fn into_iter(self) -> ExecuteResultIter<E> {
+        match self {
+            ExecuteResult::Executed(events) => ExecuteResultIter::Executed(events.into_iter()),
+            ExecuteResult::PendingTransaction { events, .. } => {
+                ExecuteResultIter::PendingTransaction(events.into_iter())
+            }
+            ExecuteResult::Idempotent => ExecuteResultIter::Idempotent,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AppendedEvent<E> {
+    pub event: E,
+    pub event_id: u64,
+    pub stream_version: u64,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub struct Execute<'a, E, C, T>
 where
     E: Entity,
 {
@@ -146,38 +284,15 @@ where
     expected_version: ExpectedVersion,
     time: DateTime<Utc>,
     executed_at: Instant,
-    tx_sender: Option<TransactionSender>,
+    transaction: T,
     phantom: PhantomData<E>,
 }
 
-pub enum ExecuteResult<E> {
-    /// The command was executed with the resulting events.
-    Executed(Vec<AppendedEvent<E>>),
-    /// The command was executed, but no new events due to idempotency
-    Idempotent,
-}
-
-impl<E> ExecuteResult<E> {
-    pub fn len(&self) -> usize {
-        match self {
-            ExecuteResult::Executed(events) => events.len(),
-            ExecuteResult::Idempotent => 0,
-        }
-    }
-
-    pub fn into_iter(self) -> impl Iterator<Item = AppendedEvent<E>> {
-        match self {
-            ExecuteResult::Executed(events) => events.into_iter(),
-            ExecuteResult::Idempotent => vec![].into_iter(),
-        }
-    }
-}
-
-impl<'a, E, C> Execute<'a, E, C>
+impl<'a, E, C, T> Execute<'a, E, C, T>
 where
     E: Entity,
 {
-    fn new(cmd_service: &'a CommandService, id: E::ID, command: C) -> Self {
+    fn new(cmd_service: &'a CommandService, id: E::ID, command: C, tx: T) -> Self {
         Execute {
             cmd_service,
             id,
@@ -186,7 +301,7 @@ where
             expected_version: ExpectedVersion::Any,
             time: Utc::now(),
             executed_at: Instant::now(),
-            tx_sender: None,
+            transaction: tx,
             phantom: PhantomData,
         }
     }
@@ -224,19 +339,14 @@ where
         self.time = time;
         self
     }
-
-    pub fn transaction(mut self, tx: &Transaction) -> Self {
-        self.tx_sender = Some(tx.sender());
-        self
-    }
 }
 
-impl<'a, E, C> IntoFuture for Execute<'a, E, C>
+impl<'a, E, C> IntoFuture for Execute<'a, E, C, ()>
 where
     E: Entity + Command<C> + Apply + Clone,
     C: Clone + Send + Sync + 'static,
 {
-    type Output = Result<ExecuteResult<E::Event>, ExecuteError<E::Error>>;
+    type Output = Result<ExecuteResult<E>, ExecuteError<E::Error>>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -246,11 +356,11 @@ where
                 .ask(ExecuteMsg {
                     id: self.id,
                     command: self.command,
-                    metadata: self.metadata,
+                    metadata: self.metadata.clone(),
                     expected_version: self.expected_version,
                     time: self.time,
                     executed_at: self.executed_at,
-                    tx_sender: self.tx_sender,
+                    tx_id: None,
                     phantom: PhantomData::<E>,
                 })
                 .send()
@@ -271,11 +381,97 @@ where
     }
 }
 
-pub struct AppendedEvent<E> {
-    pub event: E,
-    pub event_id: u64, // TODO: Make this only available when not using a transaction
-    pub stream_version: u64,
-    pub timestamp: DateTime<Utc>,
+impl<'a, 'b, E, C> IntoFuture for Execute<'a, E, C, &'a mut Transaction<'b>>
+where
+    E: Entity + Command<C> + Apply + Clone,
+    C: Clone + Send + Sync + 'static,
+{
+    type Output = Result<ExecuteResult<E>, ExecuteError<E::Error>>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        async move {
+            let stream_id = StreamID::new_from_parts(E::name(), &self.id);
+
+            let res = self
+                .cmd_service
+                .actor_ref
+                .ask(ExecuteMsg {
+                    id: self.id,
+                    command: self.command,
+                    metadata: self.metadata.clone(),
+                    expected_version: self.expected_version,
+                    time: self.time,
+                    executed_at: self.executed_at,
+                    tx_id: Some(self.transaction.id()),
+                    phantom: PhantomData::<E>,
+                })
+                .send()
+                .await
+                .map_err(|err| match err {
+                    SendError::ActorNotRunning(_) => ExecuteError::CommandServiceNotRunning,
+                    SendError::ActorStopped => ExecuteError::CommandServiceStopped,
+                    SendError::MailboxFull(_) => {
+                        unreachable!("messages aren't sent to the command service with try_")
+                    }
+                    SendError::HandlerError(err) => err,
+                    SendError::Timeout(_) => {
+                        unreachable!("messages aren't sent to the command service with timeouts")
+                    }
+                })?;
+            match res {
+                ExecuteResult::Executed(_) => panic!("expected pending transaction response"),
+                ExecuteResult::PendingTransaction {
+                    entity_actor_ref,
+                    events,
+                    expected_version,
+                    correlation_id,
+                } => {
+                    self.metadata.correlation_id = correlation_id;
+                    let metadata =
+                        GenericValue(Value::serialized(&self.metadata).map_err(|err| {
+                            ExecuteError::SerializeMetadata(ciborium::ser::Error::Value(
+                                err.to_string(),
+                            ))
+                        })?);
+
+                    let generic_events = events
+                        .iter()
+                        .map(|event| {
+                            let event_type = event.event_type();
+                            let event = GenericValue(Value::serialized(event)?);
+                            Ok((event_type, event))
+                        })
+                        .collect::<anyhow::Result<_>>()
+                        .map_err(|err| {
+                            ExecuteError::SerializeMetadata(ciborium::ser::Error::Value(
+                                err.to_string(),
+                            ))
+                        })?;
+
+                    self.transaction.append(
+                        Box::new(entity_actor_ref.clone()),
+                        AppendEvents {
+                            stream_id,
+                            events: generic_events,
+                            expected_version,
+                            metadata,
+                            timestamp: self.time,
+                        },
+                    );
+
+                    Ok(ExecuteResult::PendingTransaction {
+                        entity_actor_ref,
+                        events,
+                        expected_version,
+                        correlation_id,
+                    })
+                }
+                ExecuteResult::Idempotent => Ok(ExecuteResult::Idempotent),
+            }
+        }
+        .boxed()
+    }
 }
 
 #[derive(Debug)]
@@ -289,7 +485,7 @@ where
     expected_version: ExpectedVersion,
     time: DateTime<Utc>,
     executed_at: Instant,
-    tx_sender: Option<TransactionSender>,
+    tx_id: Option<usize>,
     phantom: PhantomData<E>,
 }
 
@@ -298,7 +494,7 @@ where
     E: Command<C> + Apply + Clone,
     C: Clone + Send + Sync + 'static,
 {
-    type Reply = DelegatedReply<Result<ExecuteResult<E::Event>, ExecuteError<E::Error>>>;
+    type Reply = DelegatedReply<Result<ExecuteResult<E>, ExecuteError<E::Error>>>;
 
     async fn handle(
         &mut self,
@@ -336,7 +532,8 @@ where
                         metadata: msg.metadata,
                         time: msg.time,
                         executed_at: msg.executed_at,
-                        tx_sender: msg.tx_sender,
+                        tx_id: msg.tx_id,
+                        is_buffered: false,
                     })
                     .forward(tx)
                     .await;
@@ -350,7 +547,8 @@ where
                         metadata: msg.metadata,
                         time: msg.time,
                         executed_at: msg.executed_at,
-                        tx_sender: msg.tx_sender,
+                        tx_id: msg.tx_id,
+                        is_buffered: false,
                     })
                     .send()
                     .await;
@@ -358,39 +556,5 @@ where
         }
 
         delegated_reply
-    }
-}
-
-pub struct PrepareStream<E> {
-    pub id: Arc<str>,
-    pub phantom: PhantomData<E>,
-}
-
-impl<E> Message<PrepareStream<E>> for CommandServiceActor
-where
-    E: Entity + Apply + Default + Send + Sync,
-{
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        msg: PrepareStream<E>,
-        ctx: Context<'_, Self, Self::Reply>,
-    ) -> Self::Reply {
-        let stream_name = StreamID::new_from_parts(E::name(), &msg.id);
-        match self.entities.get(&stream_name) {
-            Some(_) => {}
-            None => {
-                let entity_ref = kameo::actor::spawn_link(
-                    &ctx.actor_ref(),
-                    EntityActor::new(E::default(), stream_name.clone(), self.event_store.clone()),
-                )
-                .await;
-
-                self.entities
-                    .insert(stream_name, (entity_ref.id(), Box::new(entity_ref.clone())));
-                entity_ref.wait_startup().await;
-            }
-        };
     }
 }

--- a/src/entity_actor.rs
+++ b/src/entity_actor.rs
@@ -1,22 +1,17 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    time::Instant,
-};
+use std::{collections::VecDeque, time::Instant};
 
 use chrono::{DateTime, Utc};
-use ciborium::Value;
 use eventus::{CurrentVersion, ExpectedVersion};
 use futures::StreamExt;
+use im::HashMap;
 use kameo::{
-    actor::{pool::WorkerMsg, ActorRef, WeakActorRef},
+    actor::{ActorRef, WeakActorRef},
     error::{ActorStopReason, BoxError, PanicError, SendError},
     mailbox::unbounded::UnboundedMailbox,
-    message::{Context, DynMessage, Message},
-    reply::{BoxReplySender, DelegatedReply, ReplySender},
-    request::{MessageSend, MessageSendSync},
+    message::{BoxMessage, Context, Message},
+    reply::{BoxReplySender, DelegatedReply},
     Actor,
 };
-use tokio::sync::oneshot;
 use tonic::Status;
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -24,172 +19,72 @@ use uuid::Uuid;
 use crate::{
     command_service::{AppendedEvent, ExecuteResult},
     error::ExecuteError,
-    event_store::{AppendEvents, AppendEventsError, EventStore, GetStreamEvents},
+    event_store::{AppendEventsError, EventStore},
     stream_id::StreamID,
-    Apply, CausationMetadata, Command, Entity, EventType, GenericValue, Metadata,
-    TransactionResult, TransactionSender,
+    transaction::{AbortTransaction, CommitTransaction, ResetTransaction},
+    Apply, CausationMetadata, Command, Entity, Metadata,
 };
 
-pub struct EntityActor<E> {
-    entity: E,
-    stream_id: StreamID,
+pub struct EntityActor<E: Entity + Apply + Clone> {
     event_store: EventStore,
+    stream_id: StreamID,
+    state: EntityActorState<E>,
+    transaction: Option<(usize, EntityActorState<E>)>,
+    conflict_reties: usize,
+    buffered_commands: VecDeque<(
+        BoxMessage<EntityActor<E>>,
+        ActorRef<Self>,
+        Option<BoxReplySender>,
+    )>,
+    is_processing_buffered_commands: bool,
+}
+
+#[derive(Clone)]
+struct EntityActorState<E> {
+    entity: E,
     version: CurrentVersion,
     correlation_id: Uuid,
     last_causations: HashMap<Uuid, CausationMetadata>,
-    // last_causation_event_id: Option<u64>,
-    // last_causation_stream_id: Option<StreamID>,
-    // last_causation_stream_version: Option<u64>,
-    conflict_reties: usize,
-    active_tx: Option<TransactionSender>,
-    buffered_commands: VecDeque<(Option<BoxReplySender>, Box<dyn DynMessage<Self>>)>,
-    temp_entity: Option<E>,
-    temp_version: Option<CurrentVersion>,
-    temp_correlation_id: Option<Uuid>,
-    temp_last_causations: Option<HashMap<Uuid, CausationMetadata>>,
 }
 
-impl<E> EntityActor<E> {
-    pub fn new(entity: E, stream_name: StreamID, event_store: EventStore) -> Self {
-        EntityActor {
-            entity,
-            stream_id: stream_name,
-            event_store,
-            version: CurrentVersion::NoStream,
-            correlation_id: Uuid::nil(),
-            last_causations: HashMap::new(),
-            // last_causation_event_id: None,
-            // last_causation_stream_id: None,
-            // last_causation_stream_version: None,
-            conflict_reties: 5,
-            active_tx: None,
-            buffered_commands: VecDeque::new(),
-            temp_entity: None,
-            temp_version: None,
-            temp_correlation_id: None,
-            temp_last_causations: None,
-        }
-    }
-
-    fn apply(&mut self, event: E::Event, stream_version: u64, metadata: Metadata<E::Metadata>)
-    where
-        E: Entity + Apply,
-    {
-        apply_event(
-            &self.stream_id,
-            &mut self.entity,
-            &mut self.version,
-            &mut self.correlation_id,
-            &mut self.last_causations,
-            event,
+impl<E> EntityActorState<E>
+where
+    E: Entity + Apply,
+{
+    fn apply(
+        &mut self,
+        event: E::Event,
+        stream_id: &StreamID,
+        stream_version: u64,
+        metadata: Metadata<E::Metadata>,
+    ) {
+        assert_eq!(
+            match self.version {
+                CurrentVersion::Current(version) => version + 1,
+                CurrentVersion::NoStream => 0,
+            },
             stream_version,
-            metadata,
-        )
-    }
-
-    async fn resync_with_db(&mut self) -> Result<(), BoxError>
-    where
-        E: Entity + Apply,
-    {
-        let from_version = match self.version {
-            CurrentVersion::Current(version) => version + 1,
-            CurrentVersion::NoStream => 0,
-        };
-
-        let mut stream = self
-            .event_store
-            .ask(WorkerMsg(GetStreamEvents::<
-                <E as Entity>::Event,
-                <E as Entity>::Metadata,
-            >::new(
-                self.stream_id.clone(), from_version
-            )))
-            .send()
-            .await
-            .map_err(|err| err.map_msg(|WorkerMsg(msg)| msg))?;
-
-        while let Some(res) = stream.next().await {
-            let batch = res?;
-            for event in batch {
-                assert_eq!(
-                    match self.version {
-                        CurrentVersion::Current(version) => version + 1,
-                        CurrentVersion::NoStream => 0,
-                    },
-                    event.stream_version,
-                    "expected stream version {} but got {} for stream {}",
-                    match self.version {
-                        CurrentVersion::Current(version) => version + 1,
-                        CurrentVersion::NoStream => 0,
-                    },
-                    event.stream_version,
-                    event.stream_id,
-                );
-                let ent_event = ciborium::from_reader(event.event_data.as_ref())?;
-                let metadata: Metadata<E::Metadata> =
-                    ciborium::from_reader(event.metadata.as_ref())?;
-                self.apply(ent_event, event.stream_version, metadata);
-            }
+            "expected stream version {} but got {stream_version} for stream {stream_id}",
+            match self.version {
+                CurrentVersion::Current(version) => version + 1,
+                CurrentVersion::NoStream => 0,
+            },
+        );
+        let causation = metadata.causation.clone();
+        if self.correlation_id.is_nil() {
+            assert_eq!(
+                self.version,
+                CurrentVersion::NoStream,
+                "expected correlation id to be nil only if the stream doesn't exist"
+            );
+            self.correlation_id = metadata.correlation_id;
         }
+        self.entity.apply(event, metadata);
+        self.version = CurrentVersion::Current(stream_version);
 
-        Ok(())
-    }
-
-    fn hydrate_metadata_correlation_id<F>(
-        &self,
-        metadata: &mut Metadata<E::Metadata>,
-    ) -> Result<(), ExecuteError<F>>
-    where
-        E: Entity,
-    {
-        match (
-            !self.correlation_id.is_nil(),
-            !metadata.correlation_id.is_nil(),
-        ) {
-            (true, true) => {
-                // Correlation ID exists, make sure they match
-                if self.correlation_id != metadata.correlation_id {
-                    return Err(ExecuteError::CorrelationIDMismatch {
-                        existing: self.correlation_id,
-                        new: metadata.correlation_id,
-                    });
-                }
-            }
-            (true, false) => {
-                // Correlation ID exists, use the existing one
-                metadata.correlation_id = self.correlation_id;
-            }
-            (false, true) => {
-                // Correlation ID doesn't exist, make sure there's no current stream version
-                if self.version != CurrentVersion::NoStream {
-                    return Err(ExecuteError::CorrelationIDNotSetOnExistingEntity);
-                }
-            }
-            (false, false) => {
-                // Correlation ID doesn't exist, and none defined
-                metadata.correlation_id = Uuid::new_v4();
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn abort_transaction(&mut self, actor_ref: &ActorRef<Self>)
-    where
-        E: Entity + Apply,
-    {
-        println!("aborting transaction");
-        self.temp_version = None;
-        self.temp_entity = None;
-        self.temp_correlation_id = None;
-        self.temp_last_causations = None;
-        self.active_tx = None;
-        while let Some((reply_sender, exec)) = self.buffered_commands.pop_front() {
-            println!("handling buffered command...");
-            if let Some(err) = exec.handle_dyn(self, actor_ref.clone(), reply_sender).await {
-                std::panic::resume_unwind(Box::new(err));
-            }
-            println!("done handling buffered command.");
+        if let Some(causation) = causation {
+            self.last_causations
+                .insert(causation.correlation_id, causation);
         }
     }
 
@@ -201,10 +96,9 @@ impl<E> EntityActor<E> {
         expected_version: ExpectedVersion,
         time: DateTime<Utc>,
         executed_at: Instant,
-    ) -> Result<ActorExecutionResult<E::Event>, ExecuteError<E::Error>>
+    ) -> Result<Option<Vec<E::Event>>, ExecuteError<E::Error>>
     where
-        E: Entity + Command<C> + Apply,
-        C: Clone + Send,
+        E: Command<C>,
     {
         if expected_version.validate(self.version).is_err() {
             return Err(ExecuteError::IncorrectExpectedVersion {
@@ -225,96 +119,195 @@ impl<E> EntityActor<E> {
         };
         let is_idempotent = self.entity.is_idempotent(&command, ctx);
         if !is_idempotent {
-            return Ok(ActorExecutionResult::Idempotent);
+            return Ok(None);
         }
 
         let events = self
-            .temp_entity
-            .as_ref()
-            .unwrap_or(&self.entity)
+            .entity
             .handle(command, ctx)
             .map_err(ExecuteError::Handle)?;
-        if events.is_empty() {
-            return Ok(ActorExecutionResult::Events(vec![]));
-        }
 
-        match self
-            .active_tx
-            .as_ref()
-            .and_then(|active_tx| active_tx.try_clone())
-        {
-            Some(tx_sender) => {
-                let generic_events: Vec<_> = events
-                    .iter()
-                    .map(|event| {
-                        let generic_event =
-                            GenericValue(Value::serialized(event).map_err(|err| {
-                                ExecuteError::SerializeEvent(match err {
-                                    ciborium::value::Error::Custom(msg) => {
-                                        ciborium::ser::Error::Value(msg)
-                                    }
-                                })
-                            })?);
-                        Ok((event.event_type(), generic_event))
-                    })
-                    .collect::<Result<_, ExecuteError<E::Error>>>()?;
-                let generic_metadata =
-                    GenericValue(Value::serialized(&metadata).map_err(|err| {
-                        ExecuteError::SerializeMetadata(match err {
-                            ciborium::value::Error::Custom(msg) => ciborium::ser::Error::Value(msg),
-                        })
-                    })?);
-                let append = AppendEvents {
-                    stream_id: self.stream_id.clone(),
-                    events: generic_events,
-                    expected_version: self
-                        .temp_version
-                        .unwrap_or(self.version)
-                        .as_expected_version(),
-                    metadata: generic_metadata,
-                    timestamp: time,
-                };
-                let reply_receiver = tx_sender
-                    .send_events(self.stream_id.clone(), append)
-                    .map_err(|_| ExecuteError::TransactionAborted)?;
+        Ok(Some(events))
+    }
 
-                let starting_version = match self.version {
-                    CurrentVersion::Current(v) => v + 1,
-                    CurrentVersion::NoStream => 0,
-                };
-                let appended_events = events
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, event)| AppendedEvent {
-                        event,
-                        event_id: 0,
-                        stream_version: starting_version + i as u64,
-                        timestamp: Utc::now(),
-                    })
-                    .collect();
-
-                Ok(ActorExecutionResult::Transaction {
-                    events: appended_events,
-                    reply_receiver,
-                })
+    fn hydrate_metadata_correlation_id<F>(
+        &mut self,
+        metadata: &mut Metadata<E::Metadata>,
+    ) -> Result<(), ExecuteError<F>> {
+        match (
+            !self.correlation_id.is_nil(),
+            !metadata.correlation_id.is_nil(),
+        ) {
+            (true, true) => {
+                // Correlation ID exists, make sure they match
+                if &self.correlation_id != &metadata.correlation_id {
+                    return Err(ExecuteError::CorrelationIDMismatch {
+                        existing: self.correlation_id,
+                        new: metadata.correlation_id,
+                    });
+                }
             }
-            None => Ok(ActorExecutionResult::Events(events)),
+            (true, false) => {
+                // Correlation ID exists, use the existing one
+                metadata.correlation_id = self.correlation_id;
+            }
+            (false, true) => {
+                // Correlation ID doesn't exist, make sure there's no current stream version
+                if &self.version != &CurrentVersion::NoStream {
+                    return Err(ExecuteError::CorrelationIDNotSetOnExistingEntity);
+                }
+            }
+            (false, false) => {
+                // Correlation ID doesn't exist, and none defined
+                metadata.correlation_id = Uuid::new_v4();
+            }
         }
+
+        Ok(())
     }
 }
 
-enum ActorExecutionResult<E> {
-    Events(Vec<E>),
-    Idempotent,
-    Transaction {
-        events: Vec<AppendedEvent<E>>,
-        reply_receiver: oneshot::Receiver<TransactionResult>,
-    },
+impl<E: Entity + Apply + Clone> EntityActor<E> {
+    pub fn new(entity: E, stream_id: StreamID, eventus_client: EventStore) -> Self {
+        EntityActor {
+            event_store: eventus_client,
+            stream_id,
+            state: EntityActorState {
+                entity,
+                version: CurrentVersion::NoStream,
+                correlation_id: Uuid::nil(),
+                last_causations: HashMap::new(),
+            },
+            transaction: None,
+            conflict_reties: 5,
+            buffered_commands: VecDeque::new(),
+            is_processing_buffered_commands: false,
+        }
+    }
+
+    fn current_state(&mut self) -> &mut EntityActorState<E> {
+        self.transaction
+            .as_mut()
+            .map(|(_, entity)| entity)
+            .unwrap_or(&mut self.state)
+    }
+
+    async fn resync_with_db(&mut self) -> anyhow::Result<()>
+    where
+        E: Clone,
+    {
+        let from_version = match self.state.version {
+            CurrentVersion::Current(version) => version + 1,
+            CurrentVersion::NoStream => 0,
+        };
+
+        let mut stream = self
+            .event_store
+            .get_stream_events(self.stream_id.clone(), from_version)
+            .await?;
+
+        while let Some(res) = stream.next().await {
+            let batch = res?;
+            for event in batch {
+                assert_eq!(
+                    match self.state.version {
+                        CurrentVersion::Current(version) => version + 1,
+                        CurrentVersion::NoStream => 0,
+                    },
+                    event.stream_version,
+                    "expected stream version {} but got {} for stream {}",
+                    match self.state.version {
+                        CurrentVersion::Current(version) => version + 1,
+                        CurrentVersion::NoStream => 0,
+                    },
+                    event.stream_version,
+                    event.stream_id,
+                );
+                let ent_event = ciborium::from_reader(event.event_data.as_ref())?;
+                let metadata: Metadata<E::Metadata> =
+                    ciborium::from_reader(event.metadata.as_ref())?;
+                self.state
+                    .apply(ent_event, &self.stream_id, event.stream_version, metadata);
+            }
+        }
+
+        if let Some((_, tx_state)) = &mut self.transaction {
+            *tx_state = self.state.clone();
+        }
+
+        Ok(())
+    }
+
+    async fn append_events(
+        &mut self,
+        events: Vec<E::Event>,
+        metadata: Metadata<E::Metadata>,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Vec<AppendedEvent<E::Event>>, AppendEventsError<Vec<E::Event>, Metadata<E::Metadata>>>
+    {
+        let (starting_event_id, timestamp) = self
+            .event_store
+            .append_to_stream(
+                self.stream_id.clone(),
+                events.clone(),
+                self.state.version.as_expected_version(),
+                metadata.clone(),
+                timestamp,
+            )
+            .await?;
+        let starting_version = match self.state.version {
+            CurrentVersion::Current(v) => v + 1,
+            CurrentVersion::NoStream => 0,
+        };
+        let mut version = starting_version;
+
+        for event in &events {
+            self.state
+                .apply(event.clone(), &self.stream_id, version, metadata.clone());
+            version += 1;
+        }
+
+        let appended = events
+            .into_iter()
+            .enumerate()
+            .map(|(i, event)| AppendedEvent {
+                event,
+                event_id: starting_event_id + i as u64,
+                stream_version: starting_version + i as u64,
+                timestamp,
+            })
+            .collect();
+
+        Ok(appended)
+    }
+
+    fn buffer_command<C>(
+        &mut self,
+        mut exec: Execute<E::ID, C, E::Metadata>,
+        mut ctx: Context<
+            '_,
+            Self,
+            DelegatedReply<Result<ExecuteResult<E>, ExecuteError<E::Error>>>,
+        >,
+    ) -> DelegatedReply<Result<ExecuteResult<E>, ExecuteError<E::Error>>>
+    where
+        E: Command<C>,
+        C: Clone + Send + 'static,
+    {
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        exec.is_buffered = true;
+        self.buffered_commands.push_back((
+            Box::new(exec),
+            ctx.actor_ref(),
+            reply_sender.map(|tx| tx.boxed()),
+        ));
+        delegated_reply
+    }
 }
 
 impl<E> Actor for EntityActor<E>
 where
-    E: Entity + Apply,
+    E: Entity + Apply + Clone,
 {
     type Mailbox = UnboundedMailbox<Self>;
 
@@ -323,44 +316,28 @@ where
     }
 
     async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
-        if let Err(err) = self.resync_with_db().await {
-            error!("resync error: {err}");
-        }
+        self.resync_with_db().await?;
         Ok(())
     }
 
     async fn on_panic(
         &mut self,
         _actor_ref: WeakActorRef<Self>,
-        _err: PanicError,
+        err: PanicError,
     ) -> Result<Option<ActorStopReason>, BoxError> {
-        Ok(None) // Restart
+        error!("entity actor panicked: {err}");
+        Ok(Some(ActorStopReason::Panicked(err)))
     }
 
     async fn on_stop(
-        self,
+        &mut self,
         _actor_ref: WeakActorRef<Self>,
         _reason: ActorStopReason,
     ) -> Result<(), BoxError> {
+        error!("entity actor stopped");
         Ok(())
     }
 }
-
-// impl<E> Message<Event<'static>> for EntityActor<E>
-// where
-//     E: Entity + Apply,
-// {
-//     type Reply = Result<(), rmp_serde::decode::Error>;
-
-//     async fn handle(
-//         &mut self,
-//         event: Event<'static>,
-//         _ctx: Context<'_, Self, Self::Reply>,
-//     ) -> Self::Reply {
-//         self.entity.apply(rmp_serde::from_slice(&event.event_data)?);
-//         Ok(())
-//     }
-// }
 
 pub struct Execute<I, C, M> {
     pub id: I,
@@ -369,329 +346,225 @@ pub struct Execute<I, C, M> {
     pub expected_version: ExpectedVersion,
     pub time: DateTime<Utc>,
     pub executed_at: Instant,
-    pub tx_sender: Option<TransactionSender>,
+    pub tx_id: Option<usize>,
+    pub is_buffered: bool,
 }
 
 impl<E, C> Message<Execute<E::ID, C, E::Metadata>> for EntityActor<E>
 where
     E: Entity + Command<C> + Apply + Clone,
-    C: Clone + Send + Sync + 'static,
+    C: Clone + Send + 'static,
 {
-    type Reply = DelegatedReply<Result<ExecuteResult<E::Event>, ExecuteError<E::Error>>>;
+    type Reply = DelegatedReply<Result<ExecuteResult<E>, ExecuteError<E::Error>>>;
 
     async fn handle(
         &mut self,
         mut exec: Execute<E::ID, C, E::Metadata>,
         mut ctx: Context<'_, Self, Self::Reply>,
     ) -> Self::Reply {
-        println!("handle...");
-        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        if !exec.is_buffered && self.is_processing_buffered_commands {
+            return self.buffer_command(exec, ctx);
+        }
 
-        match (
-            &self.active_tx,
-            exec.tx_sender
-                .as_ref()
-                .and_then(|tx_sender| tx_sender.try_clone()),
-        ) {
-            (_, Some(TransactionSender::Retry(_))) => {
-                // Its a retry, we'll handle this now
-                println!("handling retry");
-                self.active_tx = exec.tx_sender.take();
+        match (&self.transaction, exec.tx_id) {
+            (None, None) => {} // No transaction, continue processing
+            (None, Some(tx_id)) => {
+                // New transaction, continue processing
+                self.transaction = Some((tx_id, self.state.clone()));
             }
-            (Some(active_tx), Some(tx_sender)) if active_tx.same_transaction(&tx_sender) => {
-                // Apply pending transaction events
+            (Some(_), None) => {
+                // Existing transaction, buffer
+                return self.buffer_command(exec, ctx);
             }
-            (Some(_), Some(_) | None) => {
-                println!("buffering event");
-                self.buffered_commands
-                    .push_back((reply_sender.map(ReplySender::boxed), Box::new(exec)));
-                return delegated_reply;
-            }
-            (None, tx_sender) => {
-                // if let Some(tx_sender) = &tx_sender {
-                //     if tx_sender.is_closed() {
-                //         if let Some(reply_sender) = reply_sender {
-                //             let _ = reply_sender.send(Ok(ExecuteResult::Executed(vec![])));
-                //         }
-                //         return delegated_reply;
-                //     }
-                // }
-                self.active_tx = tx_sender;
+            (Some((existing_tx_id, _)), Some(new_tx_id)) => {
+                // Existing transaction, ensure its the same one otherwise buffer
+                if existing_tx_id != &new_tx_id {
+                    return self.buffer_command(exec, ctx);
+                }
             }
         }
 
-        // Derive existing correlation ID from if not set, or generate new one
-        if let Err(err) = self.hydrate_metadata_correlation_id(&mut exec.metadata) {
-            if let Some(reply_sender) = reply_sender {
-                let _ = reply_sender.send(Err(err));
-            }
-            dbg!("return");
-            return delegated_reply;
-        }
-
-        let mut attempt = 1;
+        let mut attempt = 0;
         loop {
-            println!("loop");
-            match self.execute(
+            let state = self.current_state();
+            if let Err(err) = state.hydrate_metadata_correlation_id::<E::Error>(&mut exec.metadata)
+            {
+                return ctx.reply(Err(err));
+            }
+            let res = state.execute(
                 &exec.id,
                 exec.command.clone(),
                 &exec.metadata,
                 exec.expected_version,
                 exec.time,
                 exec.executed_at,
-            ) {
-                Ok(ActorExecutionResult::Events(events)) => {
-                    if events.is_empty() {
-                        if let Some(reply_sender) = reply_sender {
-                            reply_sender.send(Ok(ExecuteResult::Executed(vec![])));
-                        }
-                        dbg!("return");
-                        return delegated_reply;
-                    }
-                    let res = self
-                        .event_store
-                        .ask(WorkerMsg(AppendEvents {
-                            stream_id: self.stream_id.clone(),
-                            events: events.clone(),
-                            expected_version: self.version.as_expected_version(),
-                            metadata: exec.metadata.clone(),
-                            timestamp: exec.time,
-                        }))
-                        .send()
-                        .await
-                        .map_err(|err| err.map_msg(|msg| msg.0));
-                    match res {
-                        Ok((starting_event_id, timestamp)) => {
-                            let starting_version = match self.version {
+            );
+            match res {
+                Ok(Some(events)) => {
+                    match &mut self.transaction {
+                        Some((_, state)) => {
+                            // Apply to temporary state
+                            let starting_version = state.version;
+                            let mut version = match state.version {
                                 CurrentVersion::Current(v) => v + 1,
                                 CurrentVersion::NoStream => 0,
                             };
-                            let mut version = starting_version;
 
-                            for event in &events {
-                                self.apply(event.clone(), version, exec.metadata.clone());
+                            for event in events.clone() {
+                                state.apply(event, &self.stream_id, version, exec.metadata.clone());
                                 version += 1;
                             }
 
-                            let appended_events = events
-                                .into_iter()
-                                .enumerate()
-                                .map(|(i, event)| AppendedEvent {
-                                    event,
-                                    event_id: starting_event_id + i as u64,
-                                    stream_version: starting_version + i as u64,
-                                    timestamp,
-                                })
-                                .collect();
-
-                            if let Some(reply_sender) = reply_sender {
-                                reply_sender.send(Ok(ExecuteResult::Executed(appended_events)));
+                            return ctx.reply(Ok(ExecuteResult::PendingTransaction {
+                                entity_actor_ref: ctx.actor_ref(),
+                                events,
+                                expected_version: starting_version.as_expected_version(),
+                                correlation_id: exec.metadata.correlation_id,
+                            }));
+                        }
+                        None => {
+                            if events.is_empty() {
+                                return ctx.reply(Ok(ExecuteResult::Executed(vec![])));
                             }
 
-                            dbg!("return");
-                            return delegated_reply;
-                        }
-                        Err(SendError::HandlerError(
-                            AppendEventsError::IncorrectExpectedVersion {
-                                stream_id,
-                                current,
-                                expected,
-                                metadata: m,
-                                ..
-                            },
-                        )) => {
-                            debug!(%stream_id, %current, %expected, "write conflict");
-                            if attempt == self.conflict_reties {
-                                if let Some(reply_sender) = reply_sender {
-                                    reply_sender
-                                        .send(Err(ExecuteError::TooManyConflicts { stream_id }));
+                            // Append to event store directly
+                            match self.append_events(events, exec.metadata, exec.time).await {
+                                Ok(appended) => {
+                                    return ctx.reply(Ok(ExecuteResult::Executed(appended)))
                                 }
-                                return delegated_reply;
-                            }
+                                Err(AppendEventsError::IncorrectExpectedVersion {
+                                    stream_id,
+                                    current,
+                                    expected,
+                                    metadata,
+                                    ..
+                                }) => {
+                                    debug!(%stream_id, %current, %expected, "write conflict");
+                                    if attempt == self.conflict_reties {
+                                        return ctx.reply(Err(ExecuteError::TooManyConflicts {
+                                            stream_id,
+                                        }));
+                                    }
 
-                            self.resync_with_db().await.unwrap();
-
-                            exec.metadata = m;
-                            attempt += 1;
-                            exec.tx_sender = None;
-                        }
-                        Err(err) => {
-                            if let Some(reply_sender) = reply_sender {
-                                reply_sender.send(Err(err.into()));
-                            }
-                            dbg!("return");
-                            return delegated_reply;
-                        }
-                    }
-                }
-                Ok(ActorExecutionResult::Idempotent) => {
-                    if let Some(reply_sender) = reply_sender {
-                        reply_sender.send(Ok(ExecuteResult::Idempotent));
-                    }
-                    return delegated_reply;
-                }
-                Ok(ActorExecutionResult::Transaction {
-                    events,
-                    reply_receiver,
-                }) => {
-                    // Reply to actor request
-                    let events = match reply_sender {
-                        Some(reply_sender) => {
-                            let inner_events: Vec<_> = events
-                                .iter()
-                                .map(|appended| appended.event.clone())
-                                .collect();
-                            reply_sender.send(Ok(ExecuteResult::Executed(events)));
-                            inner_events
-                        }
-                        None => events.into_iter().map(|appended| appended.event).collect(),
-                    };
-
-                    // Apply to temporary state
-                    let temp_entity = self.temp_entity.get_or_insert_with(|| self.entity.clone());
-                    let temp_version = self.temp_version.get_or_insert(self.version);
-                    let temp_correlation_id =
-                        self.temp_correlation_id.get_or_insert(self.correlation_id);
-                    let temp_last_causations = self
-                        .temp_last_causations
-                        .get_or_insert_with(|| self.last_causations.clone());
-
-                    let starting_version = match temp_version {
-                        CurrentVersion::Current(v) => *v + 1,
-                        CurrentVersion::NoStream => 0,
-                    };
-                    let mut version = starting_version;
-
-                    for event in events.clone() {
-                        apply_event(
-                            &self.stream_id,
-                            temp_entity,
-                            temp_version,
-                            temp_correlation_id,
-                            temp_last_causations,
-                            event,
-                            version,
-                            exec.metadata.clone(),
-                        );
-                        version += 1;
-                    }
-
-                    let actor_ref = ctx.actor_ref();
-                    tokio::spawn(async move {
-                        println!("=== INSIDE TOKIO ACTOR SPAWN ===");
-                        // Wait for the transaction to be comitted
-                        // println!("waiting for transaction reply...");
-                        match reply_receiver.await {
-                            Ok(tx_res) => match tx_res {
-                                TransactionResult::Ok => {
-                                    println!("telling transaction comitted");
-                                    let _ = actor_ref.tell(TransactionComitted).send().await;
+                                    attempt += 1;
+                                    exec.metadata = metadata;
                                 }
-                                TransactionResult::WriteConflict { tx_sender } => {
-                                    exec.tx_sender = Some(tx_sender);
-                                    println!("telling transaction write conflict");
-                                    let _ = actor_ref
-                                        .tell(TransactionWriteConflict { exec })
-                                        .send()
-                                        .await;
-                                }
-                            },
-                            Err(_) => {
-                                println!("got err tx reply");
-                                let _ = actor_ref.tell(TransactionAborted).send().await;
+                                Err(err) => return ctx.reply(Err(err.into())),
                             }
                         }
-                        println!("=== OUTSIDE TOKIO ACTOR SPAWN ===");
-                    });
-
-                    dbg!("return");
-                    return delegated_reply;
-                }
-                Err(err) => {
-                    if let Some(reply_sender) = reply_sender {
-                        reply_sender.send(Err(err));
                     }
-                    dbg!("return");
-                    return delegated_reply;
                 }
+                Ok(None) => return ctx.reply(Ok(ExecuteResult::Idempotent)),
+                Err(err) => return ctx.reply(Err(err)),
             }
         }
     }
 }
 
-struct TransactionComitted;
+struct ProcessNextBufferedCommand;
 
-impl<E> Message<TransactionComitted> for EntityActor<E>
+impl<E> Message<ProcessNextBufferedCommand> for EntityActor<E>
 where
-    E: Entity + Apply,
+    E: Entity + Apply + Clone,
 {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: TransactionComitted,
+        _msg: ProcessNextBufferedCommand,
         ctx: Context<'_, Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.active_tx.is_some() {
-            self.version = self.temp_version.take().unwrap();
-            self.entity = self.temp_entity.take().unwrap();
-            self.correlation_id = self.temp_correlation_id.take().unwrap();
-            self.last_causations = self.temp_last_causations.take().unwrap();
-            self.active_tx = None;
-        }
+        self.is_processing_buffered_commands = true;
 
-        debug!(
-            "transaction comitted, executing {} buffered commands",
-            self.buffered_commands.len()
-        );
-
-        println!("handling buffered commands");
-        while let Some((reply_sender, exec)) = self.buffered_commands.pop_front() {
-            dbg!(reply_sender.is_some());
-            if let Some(err) = exec.handle_dyn(self, ctx.actor_ref(), reply_sender).await {
+        if let Some((exec, actor_ref, tx)) = self.buffered_commands.pop_front() {
+            if let Err(err) = exec.handle_dyn(self, actor_ref, tx).await {
                 std::panic::resume_unwind(Box::new(err));
             }
         }
+
+        // If more commands are buffered, enqueue another processing message
+        if !self.buffered_commands.is_empty() {
+            let _ = ctx.actor_ref().tell(ProcessNextBufferedCommand);
+        } else {
+            self.is_processing_buffered_commands = false;
+        }
     }
 }
 
-struct TransactionWriteConflict<I, C, M> {
-    exec: Execute<I, C, M>,
-}
-
-impl<E, C> Message<TransactionWriteConflict<E::ID, C, E::Metadata>> for EntityActor<E>
+impl<E> Message<CommitTransaction> for EntityActor<E>
 where
-    E: Entity + Command<C> + Apply + Clone,
-    C: Clone + Send + Sync + 'static,
-{
-    type Reply = Result<(), SendError<Execute<E::ID, C, E::Metadata>, ExecuteError<E::Error>>>;
-
-    async fn handle(
-        &mut self,
-        msg: TransactionWriteConflict<E::ID, C, E::Metadata>,
-        ctx: Context<'_, Self, Self::Reply>,
-    ) -> Self::Reply {
-        println!("write conflict");
-        self.resync_with_db().await.unwrap();
-        ctx.actor_ref().tell(msg.exec).send_sync()
-    }
-}
-
-struct TransactionAborted;
-
-impl<E> Message<TransactionAborted> for EntityActor<E>
-where
-    E: Entity + Apply,
+    E: Entity + Apply + Clone,
 {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: TransactionAborted,
+        msg: CommitTransaction,
         ctx: Context<'_, Self, Self::Reply>,
     ) -> Self::Reply {
-        println!("transaction aborted");
-        self.abort_transaction(&ctx.actor_ref()).await
+        if let Some((tx_id, state)) = self.transaction.take() {
+            if tx_id == msg.tx_id {
+                self.state = state;
+            } else {
+                error!("tried to commit transaction with wrong txn id");
+                return;
+            }
+        }
+
+        // Start processing buffered commands incrementally
+        if !self.is_processing_buffered_commands && !self.buffered_commands.is_empty() {
+            let _ = ctx.actor_ref().tell(ProcessNextBufferedCommand);
+        }
+    }
+}
+
+impl<E> Message<ResetTransaction> for EntityActor<E>
+where
+    E: Entity + Apply + Clone,
+{
+    type Reply = anyhow::Result<()>;
+
+    async fn handle(
+        &mut self,
+        msg: ResetTransaction,
+        _ctx: Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resync_with_db().await?;
+        if let Some((tx_id, state)) = &mut self.transaction {
+            if tx_id == &msg.tx_id {
+                *state = self.state.clone();
+            } else {
+                error!("tried to commit transaction with wrong txn id");
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<E> Message<AbortTransaction> for EntityActor<E>
+where
+    E: Entity + Apply + Clone,
+{
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: AbortTransaction,
+        ctx: Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self
+            .transaction
+            .as_ref()
+            .map(|(tx_id, _)| tx_id == &msg.tx_id)
+            .unwrap_or(false)
+        {
+            self.transaction = None;
+        }
+
+        // Start processing buffered commands incrementally
+        if !self.is_processing_buffered_commands && !self.buffered_commands.is_empty() {
+            let _ = ctx.actor_ref().tell(ProcessNextBufferedCommand);
+        }
     }
 }
 
@@ -736,49 +609,5 @@ impl<M, E> From<SendError<M, Status>> for ExecuteError<E> {
             SendError::HandlerError(err) => err.into(),
             SendError::Timeout(_) => unreachable!("no timeouts are used in the event store"),
         }
-    }
-}
-
-#[inline]
-fn apply_event<E>(
-    stream_id: &StreamID,
-    entity: &mut E,
-    current_version: &mut CurrentVersion,
-    current_correlation_id: &mut Uuid,
-    last_causations: &mut HashMap<Uuid, CausationMetadata>,
-    event: E::Event,
-    stream_version: u64,
-    metadata: Metadata<E::Metadata>,
-) where
-    E: Entity + Apply,
-{
-    assert_eq!(
-        match current_version {
-            CurrentVersion::Current(version) => *version + 1,
-            CurrentVersion::NoStream => 0,
-        },
-        stream_version,
-        "expected stream version {} but got {} for stream {}",
-        match current_version {
-            CurrentVersion::Current(version) => *version + 1,
-            CurrentVersion::NoStream => 0,
-        },
-        stream_version,
-        stream_id,
-    );
-    let causation = metadata.causation.clone();
-    if current_correlation_id.is_nil() {
-        assert_eq!(
-            *current_version,
-            CurrentVersion::NoStream,
-            "expected correlation id to be nil only if the stream doesn't exist"
-        );
-        *current_correlation_id = metadata.correlation_id;
-    }
-    entity.apply(event, metadata);
-    *current_version = CurrentVersion::Current(stream_version);
-
-    if let Some(causation) = causation {
-        last_causations.insert(causation.correlation_id, causation);
     }
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -4,8 +4,12 @@ pub mod in_memory;
 pub mod mongodb;
 #[cfg(feature = "mongodb")]
 pub mod mongodb_bulk;
+#[cfg(feature = "mongodb")]
+pub mod mongodb_correlations;
 #[cfg(feature = "polodb")]
 pub mod polodb;
+#[cfg(feature = "postgres")]
+pub mod postgres;
 
 use std::{marker::PhantomData, pin, task, vec::IntoIter};
 

--- a/src/event_handler/mongodb.rs
+++ b/src/event_handler/mongodb.rs
@@ -13,8 +13,8 @@ use crate::Event;
 use super::{CompositeEventHandler, EventHandler, EventHandlerError, EventProcessor};
 
 pub struct Session {
-    session: ClientSession,
-    dirty: bool,
+    pub(crate) session: ClientSession,
+    pub(crate) dirty: bool,
 }
 
 impl Session {

--- a/src/event_handler/mongodb_correlations.rs
+++ b/src/event_handler/mongodb_correlations.rs
@@ -1,0 +1,325 @@
+use std::{collections::HashMap, fmt, marker::PhantomData, sync::Arc};
+
+use bson::bson;
+use futures::FutureExt;
+use kameo::{
+    actor::{ActorID, ActorRef, WeakActorRef},
+    error::{ActorStopReason, BoxError, PanicError},
+    mailbox::bounded::BoundedMailbox,
+    message::{Context, Message},
+    reply::DelegatedReply,
+    request::{ForwardMessageSend, MessageSend},
+    Actor,
+};
+use mongodb::{
+    bson::doc,
+    error::{ErrorKind, WriteError, WriteFailure},
+    Client, Collection,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use crate::Event;
+
+use super::{
+    mongodb::{MongoEventProcessorError, Session},
+    CompositeEventHandler, EventHandler, EventHandlerError, EventProcessor,
+};
+
+pub struct Coordinator<E: 'static, H: Send + 'static> {
+    client: Client,
+    checkpoints_collection: Collection<Checkpoint>,
+    handler: H,
+    correlations: HashMap<Uuid, ActorRef<CorrelationWorker<E, H>>>,
+    semaphore: Arc<Semaphore>,
+    flush_interval: u64,
+}
+
+impl<E: 'static, H: Send + 'static> Coordinator<E, H> {
+    pub fn new(client: Client, checkpoints_collection: Collection<Checkpoint>, handler: H) -> Self {
+        Coordinator {
+            client,
+            checkpoints_collection,
+            handler,
+            correlations: HashMap::new(),
+            semaphore: Arc::new(Semaphore::new(50)),
+            flush_interval: 100,
+        }
+    }
+
+    /// The number of ignored events to process before performing a flush.
+    pub fn flush_interval(mut self, num_ignored_events: u64) -> Self {
+        self.flush_interval = num_ignored_events;
+        self
+    }
+
+    /// Gets a reference to the inner handler.
+    pub fn handler(&mut self) -> &mut H {
+        &mut self.handler
+    }
+}
+
+impl<E, H> EventProcessor<E, H> for ActorRef<Coordinator<E, H>>
+where
+    E: 'static,
+    H: EventHandler<Session>
+        + CompositeEventHandler<E, Session, MongoEventProcessorError>
+        + Clone
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Unpin + Sync,
+{
+    type Context = Session;
+    type Error = MongoEventProcessorError;
+
+    async fn start_from(&self) -> Result<u64, Self::Error> {
+        Ok(0)
+        // Ok(self.last_handled_event.map(|n| n + 1).unwrap_or(0))
+    }
+
+    async fn process_event(
+        &mut self,
+        event: Event,
+    ) -> Result<(), EventHandlerError<Self::Error, <H as EventHandler<Self::Context>>::Error>> {
+        self.tell(HandleEvent(event)).send().await.unwrap();
+        Ok(())
+    }
+}
+
+impl<E: 'static, H: Send + 'static> Actor for Coordinator<E, H> {
+    type Mailbox = BoundedMailbox<Self>;
+
+    async fn on_link_died(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        id: ActorID,
+        _reason: ActorStopReason,
+    ) -> Result<Option<ActorStopReason>, BoxError> {
+        self.correlations.retain(|_, worker| worker.id() != id);
+        Ok(None)
+    }
+}
+
+struct HandleEvent(Event);
+
+impl<E, H> Message<HandleEvent> for Coordinator<E, H>
+where
+    E: 'static,
+    H: EventHandler<Session>
+        + CompositeEventHandler<E, Session, MongoEventProcessorError>
+        + Clone
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Unpin + Sync,
+{
+    type Reply = DelegatedReply<
+        Result<
+            (),
+            EventHandlerError<MongoEventProcessorError, <H as EventHandler<Session>>::Error>,
+        >,
+    >;
+
+    async fn handle(
+        &mut self,
+        HandleEvent(event): HandleEvent,
+        mut ctx: Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        let correlation_worker_ref = self
+            .correlations
+            .entry(event.metadata.correlation_id)
+            .or_insert_with(|| {
+                let worker_ref = kameo::spawn(CorrelationWorker {
+                    correlation_id: event.metadata.correlation_id,
+                    client: self.client.clone(),
+                    checkpoints_collection: self.checkpoints_collection.clone(),
+                    handler: self.handler.clone(),
+                    semaphore: self.semaphore.clone(),
+                    last_handled_event: None,
+                    flush_interval: self.flush_interval,
+                    phantom: PhantomData,
+                });
+                worker_ref
+                    .link_child(&ctx.actor_ref())
+                    .now_or_never()
+                    .unwrap();
+
+                worker_ref
+            });
+
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        match reply_sender {
+            Some(reply_sender) => {
+                correlation_worker_ref
+                    .ask(HandleEvent(event))
+                    .forward(reply_sender)
+                    .await
+                    .unwrap();
+            }
+            None => {
+                correlation_worker_ref
+                    .tell(HandleEvent(event))
+                    .send()
+                    .await
+                    .unwrap();
+            }
+        }
+
+        delegated_reply
+    }
+}
+
+struct CorrelationWorker<E, H> {
+    correlation_id: Uuid,
+    client: Client,
+    checkpoints_collection: Collection<Checkpoint>,
+    handler: H,
+    semaphore: Arc<Semaphore>,
+    last_handled_event: Option<u64>,
+    flush_interval: u64,
+    phantom: PhantomData<fn() -> E>,
+}
+
+impl<E: 'static, H: Send + 'static> Actor for CorrelationWorker<E, H> {
+    type Mailbox = BoundedMailbox<Self>;
+
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+        let checkpoint = self
+            .checkpoints_collection
+            .find_one(doc! { "_id": bson::Uuid::from(self.correlation_id) })
+            .await?;
+        self.last_handled_event = checkpoint.map(|cp| cp.last_event_id);
+
+        Ok(())
+    }
+
+    async fn on_panic(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        err: PanicError,
+    ) -> Result<Option<ActorStopReason>, BoxError> {
+        error!("{err}");
+        Ok(None)
+    }
+}
+
+impl<E, H> Message<HandleEvent> for CorrelationWorker<E, H>
+where
+    E: 'static,
+    H: EventHandler<Session>
+        + CompositeEventHandler<E, Session, MongoEventProcessorError>
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Sync,
+{
+    type Reply = Result<
+        (),
+        EventHandlerError<MongoEventProcessorError, <H as EventHandler<Session>>::Error>,
+    >;
+
+    async fn handle(
+        &mut self,
+        HandleEvent(event): HandleEvent,
+        _ctx: Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        let _permit = self.semaphore.acquire().await.unwrap();
+
+        let mut session = self.client.start_session().await?;
+        session.start_transaction().await?;
+        let mut session = Session::new(session);
+
+        let event_id = event.id;
+        let res = self.handler.composite_handle(&mut session, event).await;
+        if res.is_err() {
+            let abort_res = session.abort_transaction().await;
+            res?;
+            abort_res?;
+        }
+
+        let Session { mut session, dirty } = session;
+
+        let events_since_last_flush = self
+            .last_handled_event
+            .map(|last| event_id - last)
+            .unwrap_or(u64::MAX);
+        if dirty || events_since_last_flush > self.flush_interval {
+            match self.last_handled_event {
+                Some(last_handled_event) => {
+                    let res = self.checkpoints_collection
+                    .update_one(
+                        doc! { "_id": bson::Uuid::from(self.correlation_id), "last_event_id": last_handled_event as i64 },
+                        doc! { "$set": { "last_event_id": last_handled_event as i64 } },
+                    )
+                    .session(&mut session)
+                    .await?;
+                    if res.matched_count == 0 {
+                        return Err(EventHandlerError::Processor(
+                            MongoEventProcessorError::UnexpectedLastEventId {
+                                expected: Some(last_handled_event),
+                            },
+                        ));
+                    }
+                }
+                None => {
+                    let res = self
+                        .checkpoints_collection
+                        .insert_one(Checkpoint {
+                            correlation_id: self.correlation_id,
+                            last_event_id: event_id,
+                        })
+                        .session(&mut session)
+                        .await;
+                    match res {
+                        Ok(_) => {}
+                        Err(err) => match err.kind.as_ref() {
+                            ErrorKind::Write(WriteFailure::WriteError(WriteError {
+                                code, ..
+                            })) if *code == 11000 => {
+                                return Err(EventHandlerError::Processor(
+                                    MongoEventProcessorError::UnexpectedLastEventId {
+                                        expected: None,
+                                    },
+                                ));
+                            }
+                            _ => return Err(err.into()),
+                        },
+                    }
+                }
+            }
+
+            loop {
+                let mut attempt = 1;
+                let res = session.commit_transaction().await;
+                match res {
+                    Ok(()) => {
+                        self.last_handled_event = Some(event_id);
+                        return Ok(());
+                    }
+                    Err(err) => match err.kind.as_ref() {
+                        ErrorKind::Write(WriteFailure::WriteError(WriteError { code, .. }))
+                            if *code == 112 =>
+                        {
+                            if attempt >= 1 {
+                                return Err(err.into());
+                            }
+                            attempt += 1;
+                        }
+                        _ => return Err(err.into()),
+                    },
+                }
+            }
+        } else {
+            debug!("ignoring event");
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Checkpoint {
+    #[serde(rename = "_id", with = "bson::serde_helpers::uuid_1_as_binary")]
+    correlation_id: Uuid,
+    last_event_id: u64,
+}

--- a/src/event_handler/postgres.rs
+++ b/src/event_handler/postgres.rs
@@ -1,0 +1,544 @@
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    fmt,
+    marker::PhantomData,
+    ops,
+    sync::Arc,
+};
+
+use futures::{Future, FutureExt};
+use kameo::{
+    actor::{ActorID, ActorRef, WeakActorRef},
+    error::{ActorStopReason, BoxError, PanicError},
+    mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox},
+    message::{Context, Message},
+    messages,
+    reply::DelegatedReply,
+    request::{ForwardMessageSend, MessageSend},
+    Actor,
+};
+use sqlx::{prelude::FromRow, PgPool, Postgres};
+use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use crate::Event;
+
+use super::{CompositeEventHandler, EventHandler, EventHandlerError, EventProcessor};
+
+pub struct Transaction {
+    pub(crate) tx: sqlx::Transaction<'static, Postgres>,
+    pub(crate) dirty: bool,
+}
+
+impl Transaction {
+    pub fn new(tx: sqlx::Transaction<'static, Postgres>) -> Self {
+        Transaction { tx, dirty: false }
+    }
+}
+
+impl ops::Deref for Transaction {
+    type Target = sqlx::Transaction<'static, Postgres>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
+}
+
+impl ops::DerefMut for Transaction {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.dirty = true;
+        &mut self.tx
+    }
+}
+
+pub struct Coordinator<E: 'static, H: Send + 'static> {
+    pool: PgPool,
+    checkpoints_table: Arc<str>,
+    projection_id: Arc<str>,
+    handler: H,
+    correlations: HashMap<Uuid, ActorRef<CorrelationWorker<E, H>>>,
+    global_flush_semaphore: Arc<Semaphore>,
+    flush_interval: u64,
+    global_offset_actor: ActorRef<GlobalOffsetActor>,
+}
+
+impl<E: 'static, H: Send + 'static> Coordinator<E, H> {
+    pub fn new(
+        pool: PgPool,
+        checkpoints_table: impl Into<Arc<str>>,
+        projection_id: impl Into<Arc<str>>,
+        handler: H,
+        concurrency: usize,
+    ) -> Self {
+        let checkpoints_table = checkpoints_table.into();
+        let projection_id = projection_id.into();
+        Coordinator {
+            pool: pool.clone(),
+            checkpoints_table: checkpoints_table.clone(),
+            projection_id: projection_id.clone(),
+            handler,
+            correlations: HashMap::new(),
+            global_flush_semaphore: Arc::new(Semaphore::new(concurrency)),
+            flush_interval: 100,
+            global_offset_actor: kameo::spawn(GlobalOffsetActor::new(
+                pool,
+                checkpoints_table,
+                projection_id,
+            )),
+        }
+    }
+
+    /// The number of ignored events to process before performing a flush.
+    pub fn flush_interval(mut self, num_ignored_events: u64) -> Self {
+        self.flush_interval = num_ignored_events;
+        self
+    }
+
+    /// Gets a reference to the inner handler.
+    pub fn handler(&mut self) -> &mut H {
+        &mut self.handler
+    }
+}
+
+impl<E, H> EventProcessor<E, H> for ActorRef<Coordinator<E, H>>
+where
+    E: 'static,
+    H: EventHandler<Transaction>
+        + CompositeEventHandler<E, Transaction, PostgresEventProcessorError>
+        + Clone
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Unpin + Sync,
+{
+    type Context = Transaction;
+    type Error = PostgresEventProcessorError;
+
+    async fn start_from(&self) -> Result<u64, Self::Error> {
+        // Request the global offset from Coordinator
+        let reply =
+            self.ask(GetGlobalOffset).send().await.map_err(|_| {
+                PostgresEventProcessorError::UnexpectedLastEventId { expected: None }
+            })?;
+
+        Ok(reply.map(|n| n + 1).unwrap_or(0))
+    }
+
+    async fn process_event(
+        &mut self,
+        event: Event,
+    ) -> Result<(), EventHandlerError<Self::Error, <H as EventHandler<Self::Context>>::Error>> {
+        self.tell(HandleEvent(event)).send().await.unwrap();
+        Ok(())
+    }
+}
+
+impl<E: 'static, H: Send + 'static> Actor for Coordinator<E, H> {
+    type Mailbox = BoundedMailbox<Self>;
+
+    async fn on_link_died(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        id: ActorID,
+        _reason: ActorStopReason,
+    ) -> Result<Option<ActorStopReason>, BoxError> {
+        self.correlations.retain(|_, worker| worker.id() != id);
+        Ok(None)
+    }
+}
+
+struct HandleEvent(Event);
+
+impl<E, H> Message<HandleEvent> for Coordinator<E, H>
+where
+    E: 'static,
+    H: EventHandler<Transaction>
+        + CompositeEventHandler<E, Transaction, PostgresEventProcessorError>
+        + Clone
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Unpin + Sync,
+{
+    type Reply = DelegatedReply<
+        Result<
+            (),
+            EventHandlerError<PostgresEventProcessorError, <H as EventHandler<Transaction>>::Error>,
+        >,
+    >;
+
+    fn handle(
+        &mut self,
+        HandleEvent(event): HandleEvent,
+        mut ctx: Context<'_, Self, Self::Reply>,
+    ) -> impl Future<Output = Self::Reply> + Send {
+        async move {
+            if event.metadata.correlation_id.is_nil() {
+                panic!("nil correlation id");
+            }
+
+            let permit = self
+                .global_flush_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .unwrap();
+
+            let entry = self.correlations.entry(event.metadata.correlation_id);
+            let correlation_worker_ref;
+            match entry {
+                Entry::Vacant(vacancy) => {
+                    let worker_ref = kameo::spawn(CorrelationWorker {
+                        correlation_id: event.metadata.correlation_id,
+                        pool: self.pool.clone(),
+                        checkpoints_table: self.checkpoints_table.clone(),
+                        projection_id: self.projection_id.clone(),
+                        handler: self.handler.clone(),
+                        last_handled_event: None,
+                        flush_interval: self.flush_interval,
+                        global_offset_actor: self.global_offset_actor.clone(),
+                        phantom: PhantomData,
+                    });
+                    worker_ref.link_child(&ctx.actor_ref()).await;
+
+                    correlation_worker_ref = vacancy.insert(worker_ref);
+                }
+                Entry::Occupied(occupied) => {
+                    correlation_worker_ref = occupied.into_mut();
+                }
+            }
+
+            self.global_offset_actor
+                .tell(StartProcessing {
+                    event_id: event.id,
+                    permit,
+                })
+                .send()
+                .await
+                .unwrap();
+
+            let (delegated_reply, reply_sender) = ctx.reply_sender();
+            match reply_sender {
+                Some(reply_sender) => {
+                    correlation_worker_ref
+                        .ask(HandleEvent(event))
+                        .forward(reply_sender)
+                        .await
+                        .unwrap();
+                }
+                None => {
+                    correlation_worker_ref
+                        .tell(HandleEvent(event))
+                        .send()
+                        .await
+                        .unwrap();
+                }
+            }
+
+            delegated_reply
+        }
+    }
+}
+
+struct CorrelationWorker<E, H> {
+    correlation_id: Uuid,
+    pool: PgPool,
+    checkpoints_table: Arc<str>,
+    projection_id: Arc<str>,
+    handler: H,
+    last_handled_event: Option<u64>,
+    flush_interval: u64,
+    global_offset_actor: ActorRef<GlobalOffsetActor>,
+    phantom: PhantomData<fn() -> E>,
+}
+
+impl<E: 'static, H: Send + 'static> Actor for CorrelationWorker<E, H> {
+    type Mailbox = UnboundedMailbox<Self>;
+
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+        #[derive(FromRow)]
+        struct CheckpointRow {
+            last_event_id: i64,
+        }
+
+        let checkpoint: Option<CheckpointRow> = sqlx::query_as(&format!(
+            "
+                SELECT last_event_id FROM {}
+                WHERE projection_id = $1 AND correlation_id = $2
+            ",
+            self.checkpoints_table
+        ))
+        .bind(self.projection_id.as_ref())
+        .bind(self.correlation_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        self.last_handled_event = checkpoint.map(|cp| cp.last_event_id as u64);
+
+        Ok(())
+    }
+
+    async fn on_panic(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        err: PanicError,
+    ) -> Result<Option<ActorStopReason>, BoxError> {
+        error!("{err}");
+        Ok(None)
+    }
+}
+
+impl<E: 'static, H: Send + 'static> Message<GetGlobalOffset> for Coordinator<E, H> {
+    type Reply = DelegatedReply<Option<u64>>;
+
+    async fn handle(
+        &mut self,
+        msg: GetGlobalOffset,
+        mut ctx: Context<'_, Self, Self::Reply>,
+    ) -> Self::Reply {
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        if let Some(reply_sender) = reply_sender {
+            self.global_offset_actor
+                .ask(msg)
+                .forward(reply_sender)
+                .await
+                .unwrap();
+        }
+
+        delegated_reply
+    }
+}
+
+impl<E, H> Message<HandleEvent> for CorrelationWorker<E, H>
+where
+    E: 'static,
+    H: EventHandler<Transaction>
+        + CompositeEventHandler<E, Transaction, PostgresEventProcessorError>
+        + Send
+        + 'static,
+    H::Error: fmt::Debug + Sync,
+{
+    type Reply = Result<
+        (),
+        EventHandlerError<PostgresEventProcessorError, <H as EventHandler<Transaction>>::Error>,
+    >;
+
+    fn handle(
+        &mut self,
+        HandleEvent(event): HandleEvent,
+        _ctx: Context<'_, Self, Self::Reply>,
+    ) -> impl Future<Output = Self::Reply> + Send {
+        async move {
+            let mut tx = Transaction::new(self.pool.begin().await?);
+            let event_id = event.id;
+            let res = self.handler.composite_handle(&mut tx, event).await;
+            if res.is_err() {
+                tx.tx.rollback().await?;
+                return res.map_err(|e| e.into());
+            }
+
+            let Transaction { mut tx, dirty } = tx;
+
+            let events_since_last_flush = self
+                .last_handled_event
+                .map(|last| event_id - last)
+                .unwrap_or(u64::MAX);
+            if dirty || events_since_last_flush > self.flush_interval {
+                match self.last_handled_event {
+                    Some(last_handled_event) => {
+                        let res = sqlx::query(&format!(
+                            "
+                                UPDATE {} SET last_event_id = $1
+                                WHERE projection_id = $2 AND correlation_id = $3
+                            ",
+                            self.checkpoints_table
+                        ))
+                        .bind(event_id as i64)
+                        .bind(self.projection_id.as_ref())
+                        .bind(self.correlation_id)
+                        .execute(&mut *tx)
+                        .await?;
+                        if res.rows_affected() == 0 {
+                            return Err(EventHandlerError::Processor(
+                                PostgresEventProcessorError::UnexpectedLastEventId {
+                                    expected: Some(last_handled_event),
+                                },
+                            ));
+                        }
+                    }
+                    None => {
+                        let res = sqlx::query(
+                                &format!(
+                                    "INSERT INTO {} (projection_id, correlation_id, last_event_id) VALUES ($1, $2, $3)",
+                                    self.checkpoints_table
+                                ),
+                            )
+                            .bind(self.projection_id.as_ref())
+                            .bind(self.correlation_id)
+                            .bind(event_id as i64)
+                            .execute(&mut *tx)
+                            .await;
+
+                        match res {
+                            Ok(_) => {}
+                            Err(sqlx::Error::Database(db_err))
+                                if db_err.code().as_deref() == Some("23505") =>
+                            {
+                                // 23505 is the error code for unique violations (e.g., primary key conflicts)
+                                return Err(EventHandlerError::Processor(
+                                    PostgresEventProcessorError::UnexpectedLastEventId {
+                                        expected: None,
+                                    },
+                                ));
+                            }
+                            Err(err) => return Err(err.into()),
+                        }
+                    }
+                }
+
+                tx.commit().await?;
+                self.last_handled_event = Some(event_id);
+            } else {
+                debug!("ignoring event");
+            }
+
+            // Notify the GlobalOffsetActor about the new event id.
+            self.global_offset_actor
+                .tell(FinishProcessing { event_id })
+                .send()
+                .await
+                .map_err(|_| {
+                    EventHandlerError::Processor(PostgresEventProcessorError::Postgres(
+                        sqlx::Error::RowNotFound, // Replace with appropriate error
+                    ))
+                })?;
+
+            Ok(())
+        }
+    }
+}
+
+// The GlobalOffsetWorker actor
+struct GlobalOffsetActor {
+    pool: PgPool,
+    checkpoints_table: Arc<str>,
+    projection_id: Arc<str>,
+    processing_event_ids: VecDeque<(u64, OwnedSemaphorePermit)>,
+    processed_event_ids: HashSet<u64>,
+    global_offset: Option<u64>,
+}
+
+impl Actor for GlobalOffsetActor {
+    type Mailbox = UnboundedMailbox<Self>;
+
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+        // Fetch the persisted global_offset
+        let global_offset_row: Option<(i64,)> = sqlx::query_as(&format!(
+            "SELECT last_event_id FROM {} WHERE projection_id = $1 AND correlation_id = $2",
+            self.checkpoints_table,
+        ))
+        .bind(self.projection_id.as_ref())
+        .bind(Uuid::nil())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        self.global_offset = global_offset_row.map(|(n,)| n as u64);
+
+        Ok(())
+    }
+
+    async fn on_panic(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        err: PanicError,
+    ) -> Result<Option<ActorStopReason>, BoxError> {
+        error!("GlobalOffsetActor panicked: {}", err);
+        Ok(None)
+    }
+}
+
+#[messages]
+impl GlobalOffsetActor {
+    fn new(pool: PgPool, checkpoints_table: Arc<str>, projection_id: Arc<str>) -> Self {
+        Self {
+            pool,
+            checkpoints_table,
+            projection_id,
+            processing_event_ids: VecDeque::new(),
+            processed_event_ids: HashSet::new(),
+            global_offset: None,
+        }
+    }
+
+    #[message]
+    async fn start_processing(&mut self, event_id: u64, permit: OwnedSemaphorePermit) {
+        self.processing_event_ids.push_back((event_id, permit));
+    }
+
+    #[message]
+    async fn finish_processing(&mut self, event_id: u64) -> Result<(), sqlx::Error> {
+        self.processed_event_ids.insert(event_id);
+
+        let old_global_offset = self.global_offset;
+        loop {
+            if let Some((front_event_id, _)) = self.processing_event_ids.front() {
+                if self.processed_event_ids.remove(&front_event_id) {
+                    self.global_offset = Some(*front_event_id);
+                    self.processing_event_ids.pop_front();
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if old_global_offset != self.global_offset {
+            self.persist_global_offset().await?;
+        }
+
+        Ok(())
+    }
+
+    #[message]
+    fn get_global_offset(&self) -> Option<u64> {
+        self.global_offset
+    }
+
+    // Persist the global offset to the database
+    async fn persist_global_offset(&self) -> Result<(), sqlx::Error> {
+        let Some(global_offset) = self.global_offset else {
+            return Ok(());
+        };
+
+        sqlx::query(
+            "INSERT INTO checkpoints (projection_id, correlation_id, last_event_id) 
+             VALUES ($1, $2, $3)
+             ON CONFLICT (projection_id, correlation_id) 
+             DO UPDATE SET last_event_id = EXCLUDED.last_event_id",
+        )
+        .bind(self.projection_id.as_ref())
+        .bind(Uuid::nil())
+        .bind(global_offset as i64)
+        .execute(&self.pool)
+        .await?;
+
+        info!("persisted global_offset: {global_offset}");
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresEventProcessorError {
+    #[error("unexpected last event id, expected {expected:?}")]
+    UnexpectedLastEventId { expected: Option<u64> },
+    #[error(transparent)]
+    Postgres(#[from] sqlx::Error),
+}
+
+impl<H> From<sqlx::Error> for EventHandlerError<PostgresEventProcessorError, H> {
+    fn from(err: sqlx::Error) -> Self {
+        EventHandlerError::Processor(PostgresEventProcessorError::Postgres(err))
+    }
+}

--- a/src/event_store.rs
+++ b/src/event_store.rs
@@ -1,4 +1,4 @@
-use std::{fmt, future::Future, io, marker::PhantomData};
+use std::{fmt, io};
 
 use chrono::{DateTime, Utc};
 use eventus::{
@@ -11,84 +11,249 @@ use eventus::{
     },
     CurrentVersion, Event, ExpectedVersion,
 };
-use futures::{stream::BoxStream, TryStreamExt};
-use kameo::{
-    actor::{pool::ActorPool, ActorRef},
-    message::{Context, Message},
-    Actor,
-};
+use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use prost_types::Timestamp;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use tonic::{service::interceptor::InterceptedService, transport::Channel, Code, Status};
 
 use crate::{stream_id::StreamID, Error, EventType, GenericValue};
 
-pub type EventStore = ActorRef<ActorPool<EventStoreWorker>>;
-
-pub fn new_event_store(
-    client: EventStoreClient<InterceptedService<Channel, ClientAuthInterceptor>>,
-    size: usize,
-) -> EventStore {
-    kameo::spawn(ActorPool::new(size, move || {
-        kameo::spawn(EventStoreWorker {
-            client: client.clone(),
-        })
-    }))
-}
-
-#[derive(Actor)]
-pub struct EventStoreWorker {
+#[derive(Clone, Debug)]
+pub struct EventStore {
     client: EventStoreClient<InterceptedService<Channel, ClientAuthInterceptor>>,
 }
 
-pub struct GetStreamEvents<E, M> {
-    stream_id: StreamID,
-    stream_version: u64,
-    phantom: PhantomData<(E, M)>,
-}
-
-impl<E, M> GetStreamEvents<E, M> {
-    pub fn new(stream_id: StreamID, stream_version: u64) -> GetStreamEvents<E, M> {
-        GetStreamEvents {
-            stream_id,
-            stream_version,
-            phantom: PhantomData,
-        }
+impl EventStore {
+    pub fn new(
+        client: EventStoreClient<InterceptedService<Channel, ClientAuthInterceptor>>,
+    ) -> Self {
+        EventStore { client }
     }
-}
 
-impl<E, M> Message<GetStreamEvents<E, M>> for EventStoreWorker
-where
-    E: DeserializeOwned + Send + 'static,
-    M: DeserializeOwned + Default + Unpin + Send + 'static,
-{
-    type Reply = Result<BoxStream<'static, Result<Vec<Event<'static>>, Status>>, Status>;
-
-    fn handle(
+    pub async fn get_stream_events(
         &mut self,
-        msg: GetStreamEvents<E, M>,
-        _ctx: Context<'_, Self, Self::Reply>,
-    ) -> impl Future<Output = Self::Reply> + Send {
-        async move {
-            let stream = self
-                .client
-                .get_stream_events(GetStreamEventsRequest {
-                    stream_id: msg.stream_id.into_inner(),
-                    stream_version: msg.stream_version,
-                    batch_size: 1000,
-                })
-                .await?
-                .into_inner()
-                .map_ok(|batch| {
-                    batch
-                        .events
-                        .into_iter()
-                        .map(|event| Event::<'static>::try_from(event).expect("invalid timestamp"))
-                        .collect()
-                });
+        stream_id: impl Into<String>,
+        stream_version: u64,
+    ) -> Result<BoxStream<'static, Result<Vec<Event<'static>>, Status>>, Status> {
+        Ok(self
+            .client
+            .get_stream_events(GetStreamEventsRequest {
+                stream_id: stream_id.into(),
+                stream_version,
+                batch_size: 1000,
+            })
+            .await?
+            .into_inner()
+            .map_ok(|batch| {
+                batch
+                    .events
+                    .into_iter()
+                    .map(|event| {
+                        eventus::Event::<'static>::try_from(event).expect("invalid timestamp")
+                    })
+                    .collect()
+            })
+            .boxed())
+    }
 
-            Ok(Box::pin(stream) as BoxStream<'static, _>)
+    pub async fn append_to_stream<E, M>(
+        &mut self,
+        stream_id: StreamID,
+        events: Vec<E>,
+        expected_version: ExpectedVersion,
+        metadata: M,
+        timestamp: DateTime<Utc>,
+    ) -> Result<(u64, DateTime<Utc>), AppendEventsError<Vec<E>, M>>
+    where
+        E: EventType + Serialize + Send + Sync + 'static,
+        M: Serialize + Send + Sync + 'static,
+    {
+        let mut metadata_buf = Vec::new();
+        ciborium::into_writer(&metadata, &mut metadata_buf)?;
+        let new_events = events
+            .iter()
+            .map(|event| {
+                let mut event_data = Vec::new();
+                ciborium::into_writer(&event, &mut event_data)?;
+                Ok(NewEvent {
+                    event_name: event.event_type().to_string(),
+                    event_data,
+                    metadata: metadata_buf.clone(),
+                })
+            })
+            .collect::<Result<_, ciborium::ser::Error<io::Error>>>()?;
+        let req = AppendToStreamRequest {
+            stream_id: stream_id.clone().into_inner(),
+            expected_version: Some(expected_version.into()),
+            events: new_events,
+            timestamp: Some(Timestamp {
+                seconds: timestamp.timestamp(),
+                nanos: timestamp
+                    .timestamp_subsec_nanos()
+                    .try_into()
+                    .map_err(|_| AppendEventsError::InvalidTimestamp)?,
+            }),
+        };
+
+        let res = self.client.append_to_stream(req).await;
+        let res = match res {
+            Ok(res) => res.into_inner(),
+            Err(status) => match status.code() {
+                Code::FailedPrecondition => {
+                    let current = status.metadata().get("current").unwrap();
+                    let current = match current.to_str().unwrap() {
+                        "-1" => CurrentVersion::NoStream,
+                        s => CurrentVersion::Current(s.parse::<u64>().unwrap()),
+                    };
+
+                    let expected = status.metadata().get("expected").unwrap();
+                    let expected = match expected.to_str().unwrap() {
+                        "any" => ExpectedVersion::Any,
+                        "stream_exists" => ExpectedVersion::StreamExists,
+                        "no_stream" => ExpectedVersion::NoStream,
+                        s => ExpectedVersion::Exact(s.parse::<u64>().unwrap()),
+                    };
+
+                    return Err(AppendEventsError::IncorrectExpectedVersion {
+                        stream_id,
+                        current,
+                        expected,
+                        events,
+                        metadata,
+                    });
+                }
+                _ => return Err(AppendEventsError::Database(status)),
+            },
+        };
+
+        let id = res.first_id;
+        let timestamp = res.timestamp.unwrap();
+
+        Ok((
+            id,
+            DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into().unwrap())
+                .unwrap()
+                .to_utc(),
+        ))
+    }
+
+    pub async fn append_to_streams(
+        &mut self,
+        stream_events: Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
+    ) -> Result<
+        Vec<(u64, DateTime<Utc>)>,
+        AppendEventsError<
+            Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
+            GenericValue,
+        >,
+    > {
+        let mut streams = Vec::with_capacity(stream_events.len());
+        for batch in &stream_events {
+            let mut metadata = Vec::new();
+            ciborium::into_writer(&batch.metadata, &mut metadata)?;
+            let events = batch
+                .events
+                .iter()
+                .map(|(event_name, event)| {
+                    let mut event_data = Vec::new();
+                    ciborium::into_writer(&event, &mut event_data)?;
+                    Ok(NewEvent {
+                        event_name: event_name.to_string(),
+                        event_data,
+                        metadata: metadata.clone(),
+                    })
+                })
+                .collect::<Result<_, ciborium::ser::Error<io::Error>>>()?;
+
+            streams.push(StreamEvents {
+                stream_id: batch.stream_id.clone().into_inner(),
+                expected_version: Some(batch.expected_version.into()),
+                events,
+                timestamp: Some(Timestamp {
+                    seconds: batch.timestamp.timestamp(),
+                    nanos: batch
+                        .timestamp
+                        .timestamp_subsec_nanos()
+                        .try_into()
+                        .map_err(|_| AppendEventsError::InvalidTimestamp)?,
+                }),
+            });
         }
+
+        let res = self
+            .client
+            .append_to_multiple_streams(AppendToMultipleStreamsRequest { streams })
+            .await;
+        let res = match res {
+            Ok(res) => res.into_inner(),
+            Err(status) => match status.code() {
+                Code::FailedPrecondition => {
+                    let stream_id = StreamID::new(
+                        status
+                            .metadata()
+                            .get("stream_id")
+                            .unwrap()
+                            .to_str()
+                            .unwrap()
+                            .to_string(),
+                    );
+
+                    let current = status.metadata().get("current").unwrap();
+                    let current = match current.to_str().unwrap() {
+                        "-1" => CurrentVersion::NoStream,
+                        s => CurrentVersion::Current(s.parse::<u64>().unwrap()),
+                    };
+
+                    let expected = status.metadata().get("expected").unwrap();
+                    let expected = match expected.to_str().unwrap() {
+                        "any" => ExpectedVersion::Any,
+                        "stream_exists" => ExpectedVersion::StreamExists,
+                        "no_stream" => ExpectedVersion::NoStream,
+                        s => ExpectedVersion::Exact(s.parse::<u64>().unwrap()),
+                    };
+
+                    let (events, metadata) = stream_events.into_iter().fold(
+                        (Vec::new(), None),
+                        |(mut events, mut metadata), append| {
+                            if append.stream_id == stream_id {
+                                metadata = Some(append.metadata);
+                            } else {
+                                events.push(append);
+                            }
+                            (events, metadata)
+                        },
+                    );
+
+                    return Err(AppendEventsError::IncorrectExpectedVersion {
+                        stream_id,
+                        current,
+                        expected,
+                        events,
+                        metadata: metadata.unwrap(),
+                    });
+                }
+                _ => return Err(AppendEventsError::Database(status)),
+            },
+        };
+
+        let results = res
+            .streams
+            .into_iter()
+            .map(|res| {
+                let timestamp = res.timestamp.unwrap();
+                (
+                    res.first_id,
+                    DateTime::from_timestamp(
+                        timestamp.seconds,
+                        timestamp.nanos.try_into().unwrap(),
+                    )
+                    .unwrap()
+                    .to_utc(),
+                )
+            })
+            .collect();
+
+        Ok(results)
     }
 }
 
@@ -136,221 +301,6 @@ impl<E, M> fmt::Debug for AppendEventsError<E, M> {
                 .finish(),
             Self::InvalidTimestamp => f.debug_struct("InvalidTimestamp").finish(),
             Self::SerializeEvent(ev) => f.debug_tuple("SerializeEvent").field(ev).finish(),
-        }
-    }
-}
-
-impl<E, M> Message<AppendEvents<E, M>> for EventStoreWorker
-where
-    E: EventType + Serialize + Send + Sync + 'static,
-    M: Serialize + Send + Sync + 'static,
-{
-    type Reply = Result<(u64, DateTime<Utc>), AppendEventsError<Vec<E>, M>>;
-
-    async fn handle(
-        &mut self,
-        msg: AppendEvents<E, M>,
-        _ctx: Context<'_, Self, Self::Reply>,
-    ) -> Self::Reply {
-        let mut metadata = Vec::new();
-        ciborium::into_writer(&msg.metadata, &mut metadata)?;
-        let events = msg
-            .events
-            .iter()
-            .map(|event| {
-                let mut event_data = Vec::new();
-                ciborium::into_writer(&event, &mut event_data)?;
-                Ok(NewEvent {
-                    event_name: event.event_type().to_string(),
-                    event_data,
-                    metadata: metadata.clone(),
-                })
-            })
-            .collect::<Result<_, ciborium::ser::Error<io::Error>>>()?;
-        let req = AppendToStreamRequest {
-            stream_id: msg.stream_id.clone().into_inner(),
-            expected_version: Some(msg.expected_version.into()),
-            events,
-            timestamp: Some(Timestamp {
-                seconds: msg.timestamp.timestamp(),
-                nanos: msg
-                    .timestamp
-                    .timestamp_subsec_nanos()
-                    .try_into()
-                    .map_err(|_| AppendEventsError::InvalidTimestamp)?,
-            }),
-        };
-
-        let res = self.client.append_to_stream(req).await;
-        let res = match res {
-            Ok(res) => res.into_inner(),
-            Err(status) => match status.code() {
-                Code::FailedPrecondition => {
-                    let current = status.metadata().get("current").unwrap();
-                    let current = match current.to_str().unwrap() {
-                        "-1" => CurrentVersion::NoStream,
-                        s => CurrentVersion::Current(s.parse::<u64>().unwrap()),
-                    };
-
-                    let expected = status.metadata().get("expected").unwrap();
-                    let expected = match expected.to_str().unwrap() {
-                        "any" => ExpectedVersion::Any,
-                        "stream_exists" => ExpectedVersion::StreamExists,
-                        "no_stream" => ExpectedVersion::NoStream,
-                        s => ExpectedVersion::Exact(s.parse::<u64>().unwrap()),
-                    };
-
-                    return Err(AppendEventsError::IncorrectExpectedVersion {
-                        stream_id: msg.stream_id,
-                        current,
-                        expected,
-                        events: msg.events,
-                        metadata: msg.metadata,
-                    });
-                }
-                _ => return Err(AppendEventsError::Database(status)),
-            },
-        };
-
-        let id = res.first_id;
-        let timestamp = res.timestamp.unwrap();
-
-        Ok((
-            id,
-            DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into().unwrap())
-                .unwrap()
-                .to_utc(),
-        ))
-    }
-}
-
-#[derive(Debug)]
-pub struct AppendTransactionEvents {
-    pub stream_events: Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
-}
-
-impl Message<AppendTransactionEvents> for EventStoreWorker {
-    type Reply = Result<
-        Vec<(u64, DateTime<Utc>)>,
-        AppendEventsError<
-            Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
-            GenericValue,
-        >,
-    >;
-
-    fn handle(
-        &mut self,
-        msg: AppendTransactionEvents,
-        _ctx: Context<'_, Self, Self::Reply>,
-    ) -> impl Future<Output = Self::Reply> + Send {
-        async move {
-            let mut streams = Vec::with_capacity(msg.stream_events.len());
-            for batch in &msg.stream_events {
-                let mut metadata = Vec::new();
-                ciborium::into_writer(&batch.metadata, &mut metadata)?;
-                let events = batch
-                    .events
-                    .iter()
-                    .map(|(event_name, event)| {
-                        let mut event_data = Vec::new();
-                        ciborium::into_writer(&event, &mut event_data)?;
-                        Ok(NewEvent {
-                            event_name: event_name.to_string(),
-                            event_data,
-                            metadata: metadata.clone(),
-                        })
-                    })
-                    .collect::<Result<_, ciborium::ser::Error<io::Error>>>()?;
-
-                streams.push(StreamEvents {
-                    stream_id: batch.stream_id.clone().into_inner(),
-                    expected_version: Some(batch.expected_version.into()),
-                    events,
-                    timestamp: Some(Timestamp {
-                        seconds: batch.timestamp.timestamp(),
-                        nanos: batch
-                            .timestamp
-                            .timestamp_subsec_nanos()
-                            .try_into()
-                            .map_err(|_| AppendEventsError::InvalidTimestamp)?,
-                    }),
-                });
-            }
-
-            let res = self
-                .client
-                .append_to_multiple_streams(AppendToMultipleStreamsRequest { streams })
-                .await;
-            let res = match res {
-                Ok(res) => res.into_inner(),
-                Err(status) => match status.code() {
-                    Code::FailedPrecondition => {
-                        let stream_id = StreamID::new(
-                            status
-                                .metadata()
-                                .get("stream_id")
-                                .unwrap()
-                                .to_str()
-                                .unwrap()
-                                .to_string(),
-                        );
-
-                        let current = status.metadata().get("current").unwrap();
-                        let current = match current.to_str().unwrap() {
-                            "-1" => CurrentVersion::NoStream,
-                            s => CurrentVersion::Current(s.parse::<u64>().unwrap()),
-                        };
-
-                        let expected = status.metadata().get("expected").unwrap();
-                        let expected = match expected.to_str().unwrap() {
-                            "any" => ExpectedVersion::Any,
-                            "stream_exists" => ExpectedVersion::StreamExists,
-                            "no_stream" => ExpectedVersion::NoStream,
-                            s => ExpectedVersion::Exact(s.parse::<u64>().unwrap()),
-                        };
-
-                        let (events, metadata) = msg.stream_events.into_iter().fold(
-                            (Vec::new(), None),
-                            |(mut events, mut metadata), append| {
-                                if append.stream_id == stream_id {
-                                    metadata = Some(append.metadata);
-                                } else {
-                                    events.push(append);
-                                }
-                                (events, metadata)
-                            },
-                        );
-
-                        return Err(AppendEventsError::IncorrectExpectedVersion {
-                            stream_id,
-                            current,
-                            expected,
-                            events,
-                            metadata: metadata.unwrap(),
-                        });
-                    }
-                    _ => return Err(AppendEventsError::Database(status)),
-                },
-            };
-
-            let results = res
-                .streams
-                .into_iter()
-                .map(|res| {
-                    let timestamp = res.timestamp.unwrap();
-                    (
-                        res.first_id,
-                        DateTime::from_timestamp(
-                            timestamp.seconds,
-                            timestamp.nanos.try_into().unwrap(),
-                        )
-                        .unwrap()
-                        .to_utc(),
-                    )
-                })
-                .collect();
-
-            Ok(results)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,26 @@
 pub mod command_service;
-mod entity_actor;
+pub mod entity_actor;
 pub mod error;
 pub mod event_handler;
 mod event_store;
 pub mod stream_id;
 pub mod test_utils;
+pub mod transaction;
 
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    convert::Infallible,
-    fmt, io, ops,
-    str::FromStr,
-    time::Instant,
-};
+use std::{convert::Infallible, fmt, io, ops, str::FromStr, time::Instant};
 
-use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use ciborium::Value;
-use event_store::{AppendEvents, AppendEventsError, AppendTransactionEvents, EventStore};
 use eventus::server::eventstore::{
     event_store_client::EventStoreClient, subscribe_request::StartFrom, EventBatch,
     SubscribeRequest,
 };
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
-use kameo::{actor::pool::WorkerMsg, error::SendError, request::MessageSend};
+use kameo::error::SendError;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use stream_id::StreamID;
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
 use tonic::{transport::Channel, Code, Status};
-use tracing::debug;
 use uuid::Uuid;
 
 pub trait Entity: Default + Send + 'static {
@@ -367,192 +358,6 @@ impl ops::DerefMut for GenericValue {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
-}
-
-#[derive(Debug)]
-pub struct Transaction {
-    event_store: EventStore,
-    receiver: mpsc::UnboundedReceiver<TransactionMessage>,
-    sender: mpsc::UnboundedSender<TransactionMessage>,
-}
-
-impl Transaction {
-    pub(crate) fn new(event_store: EventStore) -> Self {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        Transaction {
-            event_store,
-            receiver,
-            sender,
-        }
-    }
-
-    pub async fn commit(mut self) -> anyhow::Result<()> {
-        self.receiver.close();
-
-        let mut reply_senders: HashMap<StreamID, Vec<oneshot::Sender<TransactionResult>>> =
-            HashMap::new();
-        let mut stream_events = Vec::new();
-        while let Some(TransactionMessage {
-            stream_id,
-            reply_sender,
-            append,
-        }) = self.receiver.recv().await
-        {
-            match reply_senders.entry(stream_id) {
-                Entry::Occupied(mut entry) => {
-                    entry.get_mut().push(reply_sender);
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(vec![reply_sender]);
-                }
-            }
-            if !append.events.is_empty() {
-                stream_events.push(append);
-            }
-        }
-
-        if stream_events.is_empty() {
-            return Ok(());
-        }
-
-        let mut attempt = 1;
-        loop {
-            let res = self
-                .event_store
-                .ask(WorkerMsg(AppendTransactionEvents { stream_events }))
-                .send()
-                .await;
-            match res {
-                Ok(_) => {
-                    for (_, reply_senders) in reply_senders {
-                        for reply_sender in reply_senders {
-                            let _ = reply_sender.send(TransactionResult::Ok);
-                        }
-                    }
-                    return Ok(());
-                }
-                Err(SendError::HandlerError(AppendEventsError::IncorrectExpectedVersion {
-                    stream_id,
-                    current,
-                    expected,
-                    events,
-                    ..
-                })) => {
-                    debug!(%stream_id, %current, %expected, "write conflict");
-                    if attempt == 5 {
-                        return Err(anyhow!("too many conflict retries"));
-                    }
-
-                    stream_events = events;
-                    attempt += 1;
-
-                    let mut retry_receivers = Vec::with_capacity(reply_senders.len());
-                    for reply_sender in reply_senders.remove(&stream_id).unwrap() {
-                        let (retry_sender, retry_receiver) = oneshot::channel();
-
-                        let _ = reply_sender.send(TransactionResult::WriteConflict {
-                            tx_sender: TransactionSender::Retry(retry_sender),
-                        });
-                        retry_receivers.push(retry_receiver);
-                    }
-                    for retry_receiver in retry_receivers {
-                        let tx_msg = retry_receiver.await?;
-                        match reply_senders.entry(tx_msg.stream_id) {
-                            Entry::Occupied(mut entry) => {
-                                entry.get_mut().push(tx_msg.reply_sender);
-                            }
-                            Entry::Vacant(entry) => {
-                                entry.insert(vec![tx_msg.reply_sender]);
-                            }
-                        }
-                        if !tx_msg.append.events.is_empty() {
-                            stream_events.push(tx_msg.append);
-                        }
-                        if stream_events.is_empty() {
-                            return Ok(());
-                        }
-                    }
-                }
-                Err(err) => return Err(err.into()),
-            }
-        }
-    }
-
-    pub(crate) fn sender(&self) -> TransactionSender {
-        TransactionSender::Initial(self.sender.clone())
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct TransactionMessage {
-    stream_id: StreamID,
-    reply_sender: oneshot::Sender<TransactionResult>,
-    append: AppendEvents<(&'static str, GenericValue), GenericValue>,
-}
-
-#[derive(Debug)]
-pub(crate) enum TransactionSender {
-    Initial(mpsc::UnboundedSender<TransactionMessage>),
-    Retry(oneshot::Sender<TransactionMessage>),
-}
-
-impl TransactionSender {
-    pub(crate) fn send_events(
-        self,
-        stream_id: StreamID,
-        append: AppendEvents<(&'static str, GenericValue), GenericValue>,
-    ) -> anyhow::Result<oneshot::Receiver<TransactionResult>> {
-        let (reply_sender, reply_receiver) = oneshot::channel();
-        match self {
-            TransactionSender::Initial(sender) => {
-                sender.send(TransactionMessage {
-                    stream_id,
-                    reply_sender,
-                    append,
-                })?;
-            }
-            TransactionSender::Retry(sender) => {
-                sender
-                    .send(TransactionMessage {
-                        stream_id,
-                        reply_sender,
-                        append,
-                    })
-                    .map_err(|_| anyhow!("failed to send to retry transaction sender"))?;
-            }
-        }
-
-        Ok(reply_receiver)
-    }
-
-    pub(crate) fn same_transaction(&self, other: &Self) -> bool {
-        match (self, other) {
-            (TransactionSender::Initial(a), TransactionSender::Initial(b)) => a.same_channel(b),
-            _ => false,
-        }
-    }
-
-    pub(crate) fn is_closed(&self) -> bool {
-        match self {
-            TransactionSender::Initial(tx) => tx.is_closed(),
-            TransactionSender::Retry(tx) => tx.is_closed(),
-        }
-    }
-
-    pub(crate) fn try_clone(&self) -> Option<TransactionSender> {
-        match self {
-            TransactionSender::Initial(tx_sender) => {
-                Some(TransactionSender::Initial(tx_sender.clone()))
-            }
-            TransactionSender::Retry(_) => None,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum TransactionResult {
-    Ok,
-    WriteConflict { tx_sender: TransactionSender },
 }
 
 /// Matches on an event for multiple branches, with each branch being an entity type.

--- a/src/stream_id.rs
+++ b/src/stream_id.rs
@@ -215,6 +215,12 @@ impl StreamID {
     }
 }
 
+impl From<StreamID> for String {
+    fn from(stream_id: StreamID) -> Self {
+        stream_id.into_inner()
+    }
+}
+
 impl fmt::Display for StreamID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,134 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use kameo::{
+    actor::ActorRef,
+    error::{Infallible, SendError},
+    mailbox::unbounded::UnboundedMailbox,
+    message::Message,
+    request::MessageSendSync,
+    Actor,
+};
+
+use crate::{
+    command_service::CommandService, event_store::AppendEvents, stream_id::StreamID, GenericValue,
+};
+
+pub struct Transaction<'a> {
+    id: usize,
+    pub(crate) cmd_service: &'a CommandService,
+    entities: &'a mut HashMap<StreamID, Box<dyn EntityTransaction>>,
+    appends: &'a mut Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
+}
+
+impl<'a> Transaction<'a> {
+    pub(crate) fn new(
+        id: usize,
+        cmd_service: &'a CommandService,
+        entities: &'a mut HashMap<StreamID, Box<dyn EntityTransaction>>,
+        appends: &'a mut Vec<AppendEvents<(&'static str, GenericValue), GenericValue>>,
+    ) -> Self {
+        Transaction {
+            id,
+            cmd_service,
+            entities,
+            appends,
+        }
+    }
+
+    pub(crate) fn id(&self) -> usize {
+        self.id
+    }
+
+    pub(crate) fn append(
+        &mut self,
+        entity_actor_ref: Box<dyn EntityTransaction>,
+        append: AppendEvents<(&'static str, GenericValue), GenericValue>,
+    ) {
+        self.entities
+            .entry(append.stream_id.clone())
+            .or_insert(entity_actor_ref);
+        self.appends.push(append);
+    }
+
+    pub(crate) fn committed(self) {
+        for (_, entity) in self.entities {
+            let _ = entity.commit_transaction(self.id);
+        }
+    }
+
+    pub(crate) fn reset(self) {
+        for (_, entity) in &*self.entities {
+            let _ = entity.reset_transaction(self.id);
+        }
+        // self.entities.clear();
+        self.appends.clear();
+    }
+
+    pub(crate) fn abort(self) {
+        for (_, entity) in self.entities {
+            let _ = entity.abort_transaction(self.id);
+        }
+    }
+
+    pub(crate) fn get_id() -> usize {
+        static COUNTER: AtomicUsize = AtomicUsize::new(1);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+pub(crate) struct CommitTransaction {
+    pub(crate) tx_id: usize,
+}
+pub(crate) struct ResetTransaction {
+    pub(crate) tx_id: usize,
+}
+pub(crate) struct AbortTransaction {
+    pub(crate) tx_id: usize,
+}
+
+pub(crate) trait EntityTransaction: Send + 'static {
+    fn commit_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<CommitTransaction, Infallible>>;
+    fn reset_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<ResetTransaction, anyhow::Error>>;
+    fn abort_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<AbortTransaction, Infallible>>;
+}
+
+impl<A> EntityTransaction for ActorRef<A>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>>
+        + Message<CommitTransaction, Reply = ()>
+        + Message<ResetTransaction, Reply = anyhow::Result<()>>
+        + Message<AbortTransaction, Reply = ()>,
+{
+    fn commit_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<CommitTransaction, Infallible>> {
+        self.tell(CommitTransaction { tx_id }).send_sync()
+    }
+
+    fn reset_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<ResetTransaction, anyhow::Error>> {
+        self.tell(ResetTransaction { tx_id }).send_sync()
+    }
+
+    fn abort_transaction(
+        &self,
+        tx_id: usize,
+    ) -> Result<(), SendError<AbortTransaction, Infallible>> {
+        self.tell(AbortTransaction { tx_id }).send_sync()
+    }
+}


### PR DESCRIPTION
If you want to use postgres, you'll need to have a `checkpoints` table which looks like so:

```sql
CREATE TABLE checkpoints (
  projection_id TEXT NOT NULL,
  correlation_id UUID NOT NULL,
  last_event_id BIGINT NOT NULL,
  PRIMARY KEY (projection_id, correlation_id)
);
```

The primary key can be an arbitrary name of your projection. The postgres event handler runs your projection concurrently by `correlation_id`. So if you rely on ordering between some specific events, ensure they share the same correlation id.